### PR TITLE
more useful & cleaner debugging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,21 @@ let __DEBUG__;
 function debug(...args) {
   if (__DEBUG__) console.log('%credux-undo', 'font-style: italic', ...args);
 }
+function debugStart(action, state) {
+  if (__DEBUG__) {
+    const args = ['enhanced reducer called:', action, {state}];
+    if (console.group) {
+      console.groupCollapsed(...args);
+    } else {
+      console.log(...args);
+    }
+  }
+}
+function debugEnd() {
+  if (__DEBUG__) {
+    console.groupEnd && console.groupEnd();
+  }
+}
 // /debug output
 
 // action types
@@ -34,7 +49,7 @@ function length(history) {
 //         into `past`, setting the new `state` as `present` and erasing
 //         the `future`.
 function insert(history, state, limit) {
-  debug('insert(', history, state, limit, ')');
+  debug('insert(', {history, state, free: limit - length(history)}, ')');
 
   const { past, present } = history;
   const historyOverflow = limit && length(history) >= limit;
@@ -61,7 +76,7 @@ function insert(history, state, limit) {
 
 // undo: go back to the previous point in history
 function undo(history) {
-  debug('undo(', history, ')');
+  debug('undo(', {history}, ')');
 
   const { past, present, future } = history;
 
@@ -80,7 +95,7 @@ function undo(history) {
 
 // redo: go to the next point in history
 function redo(history) {
-  debug('redo(', history, ')');
+  debug('redo(', {history}, ')');
 
   const { past, present, future } = history;
 
@@ -107,20 +122,6 @@ function updateState(state, history) {
 }
 // /updateState
 
-// arrayToString
-function arrayToString(array) {
-  if (!array || array.length <= 0) return '_';
-  return array.join(',');
-}
-
-// historyToString
-function historyToString(history) {
-  return arrayToString(history.past) +
-    ' | ' + history.present +
-    ' | ' + arrayToString(history.future);
-}
-// /historyToString
-
 // redux-undo higher order reducer
 export default function undoable(reducer, rawConfig = {}) {
   __DEBUG__ = rawConfig.debug;
@@ -139,17 +140,19 @@ export default function undoable(reducer, rawConfig = {}) {
   };
 
   return (state, action) => {
-    debug('enhanced reducer called:', state, action);
+    debugStart(action, state);
     let res;
     switch (action.type) {
     case config.undoType:
       res = undo(state.history, action.steps);
-      debug('history (undo):', historyToString(state.history), '->', historyToString(res));
+      debug('history (undo):', res);
+      debugEnd();
       return res ? updateState(state, res) : state;
 
     case config.redoType:
       res = redo(state.history, action.steps);
-      debug('history (redo):', historyToString(state.history), '->', historyToString(res));
+      debug('history (redo):', res);
+      debugEnd();
       return res ? updateState(state, res) : state;
 
     default:
@@ -158,6 +161,7 @@ export default function undoable(reducer, rawConfig = {}) {
       if (config.filter && typeof config.filter === 'function') {
         if (!config.filter(action)) {
           debug('filter prevented action, not storing it');
+          debugEnd();
           return {
             ...state,
             currentState: res,
@@ -167,7 +171,8 @@ export default function undoable(reducer, rawConfig = {}) {
 
       const history = (state && state.history !== undefined) ? state.history : config.history;
       const updatedHistory = insert(history, res, config.limit);
-      debug('history (insert):', historyToString(history), '->', historyToString(updatedHistory));
+      debug('history (insert):', updatedHistory);
+      debugEnd();
 
       return {
         ...state,

--- a/src/index.js
+++ b/src/index.js
@@ -178,7 +178,7 @@ export default function undoable(reducer, rawConfig = {}) {
 
       const history = (state && state.history !== undefined) ? state.history : config.history;
       const updatedHistory = insert(history, res, config.limit);
-      debug('after insert', {history: updatedHistory, free: config.limit - length(history)});
+      debug('after insert', {history: updatedHistory, free: config.limit - length(updatedHistory)});
       debugEnd();
 
       return {


### PR DESCRIPTION
Yeah, it was real mess with a lot of actions going around (especially when redux-devtools replays everything). So I've grouped relevant things together and got rid of the `historyToString` because it just generated bunch of `[object Object]` strings which you cannot really investigate in any way.

I think that eventually it might be better to just use https://www.npmjs.com/package/debug which is rather wide spread and people can configure what debugging message they want to see.