### PR TITLE
History reset respects initialState

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -246,9 +246,8 @@ export default function undoable (reducer, rawConfig = {}) {
         return res ? updateState(state, res) : state
 
       default:
-        res = reducer(state && state.present, action)
-
         if (config.initTypes.some((actionType) => actionType === action.type)) {
+          res = reducer(config.history.present, action)
           debug('reset history due to init action')
           debugEnd()
           return wrapState({
@@ -256,6 +255,8 @@ export default function undoable (reducer, rawConfig = {}) {
             ...createHistory(res)
           })
         }
+
+        res = reducer(state && state.present, action)
 
         if (config.filter && typeof config.filter === 'function') {
           if (!config.filter(action, res, state && state.present)) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -5,10 +5,11 @@ describe('Undoable', () => {
   let mockUndoableReducer
   let mockInitialState
   let incrementedState
+  let countReducer
 
   before('setup mock reducers and states', () => {
     let countInitialState = 0
-    let countReducer = (state = countInitialState, action = {}) => {
+    countReducer = (state = countInitialState, action = {}) => {
       switch (action.type) {
         case 'INCREMENT':
           return state + 1
@@ -54,6 +55,17 @@ describe('Undoable', () => {
 
     expect(reInitializedState.past.length).to.equal(0)
     expect(reInitializedState.future.length).to.equal(0)
+  })
+
+  it('should apply initialState', () => {
+    let reducer = undoable(countReducer, {
+      initialState: 4,
+      initTypes: 'RE-INITIALIZE'
+    })
+    let state = { past: [], present: 4, future: [] }
+    state = reducer(state, { type: 'INCREMENT' })
+    state = reducer(state, { type: 'RE-INITIALIZE' })
+    expect(state.present).to.equal(4)
   })
 
   describe('Undo', () => {


### PR DESCRIPTION
I'm using redux-undo in an Electron project that involves (sometimes) loading initial state from disk. I found setting `initialState` didn't persist through the reset that happens when Redux initializes. This patch always uses `config.history` as the initial state during a reset. (Test coverage included.)

I believe this is a simple fix for existing users, unless they are relying on initialState _not_ actually being set correctly.