### PR TITLE
 remove history property（leaving past, present, future）

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -251,7 +251,7 @@ export default function undoable (reducer, rawConfig = {}) {
         const updatedHistory = insert(history, res, config.limit)
         debug('after insert', {history: updatedHistory, free: config.limit - length(updatedHistory)})
         debugEnd()
-        return updatedHistory;
+        return updatedHistory
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -158,12 +158,6 @@ function jumpToPast (history, index) {
 }
 // /jumpToPast
 
-// updateState
-function updateState (state, history) {
-  return {...state, ...history}
-}
-// /updateState
-
 // createHistory
 function createHistory (state) {
   return {
@@ -213,25 +207,25 @@ export default function undoable (reducer, rawConfig = {}) {
         res = undo(state)
         debug('after undo', res)
         debugEnd()
-        return res ? updateState(state, res) : state
+        return res
 
       case config.redoType:
         res = redo(state)
         debug('after redo', res)
         debugEnd()
-        return res ? updateState(state, res) : state
+        return res
 
       case config.jumpToPastType:
         res = jumpToPast(state, action.index)
         debug('after jumpToPast', res)
         debugEnd()
-        return res ? updateState(state, res) : state
+        return res
 
       case config.jumpToFutureType:
         res = jumpToFuture(state, action.index)
         debug('after jumpToFuture', res)
         debugEnd()
-        return res ? updateState(state, res) : state
+        return res
 
       default:
         res = reducer(state && state.present, action)
@@ -239,10 +233,7 @@ export default function undoable (reducer, rawConfig = {}) {
         if (config.initTypes.some((actionType) => actionType === action.type)) {
           debug('reset history due to init action')
           debugEnd()
-          return {
-            ...state,
-            ...createHistory(res)
-          }
+          return createHistory(res)
         }
 
         if (config.filter && typeof config.filter === 'function') {
@@ -260,11 +251,7 @@ export default function undoable (reducer, rawConfig = {}) {
         const updatedHistory = insert(history, res, config.limit)
         debug('after insert', {history: updatedHistory, free: config.limit - length(updatedHistory)})
         debugEnd()
-
-        return {
-          ...state,
-          ...updatedHistory
-        }
+        return updatedHistory;
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,7 @@ function jumpToPast (history, index) {
 
 // updateState
 function updateState (state, history) {
-  return {...state, ...history};
+  return {...state, ...history}
 }
 // /updateState
 
@@ -193,7 +193,7 @@ export default function undoable (reducer, rawConfig = {}) {
     initialState: rawConfig.initialState,
     initTypes: parseActions(rawConfig.initTypes, ['@@redux/INIT', '@@INIT']),
     limit: rawConfig.limit,
-    filter: rawConfig.filter || () => true,
+    filter: rawConfig.filter || (() => true),
     undoType: rawConfig.undoType || ActionTypes.UNDO,
     redoType: rawConfig.redoType || ActionTypes.REDO,
     jumpToPastType: rawConfig.jumpToPastType || ActionTypes.JUMP_TO_PAST,

--- a/src/index.js
+++ b/src/index.js
@@ -158,21 +158,9 @@ function jumpToPast (history, index) {
 }
 // /jumpToPast
 
-// wrapState: for backwards compatibility to 0.4
-function wrapState (state) {
-  return {
-    ...state,
-    history: state
-  }
-}
-// /wrapState
-
 // updateState
 function updateState (state, history) {
-  return wrapState({
-    ...state,
-    ...history
-  })
+  return {...state, ...history};
 }
 // /updateState
 
@@ -251,20 +239,20 @@ export default function undoable (reducer, rawConfig = {}) {
         if (config.initTypes.some((actionType) => actionType === action.type)) {
           debug('reset history due to init action')
           debugEnd()
-          return wrapState({
+          return {
             ...state,
             ...createHistory(res)
-          })
+          }
         }
 
         if (config.filter && typeof config.filter === 'function') {
           if (!config.filter(action, res, state && state.present)) {
             debug('filter prevented action, not storing it')
             debugEnd()
-            return wrapState({
+            return {
               ...state,
               present: res
-            })
+            }
           }
         }
 
@@ -273,10 +261,10 @@ export default function undoable (reducer, rawConfig = {}) {
         debug('after insert', {history: updatedHistory, free: config.limit - length(updatedHistory)})
         debugEnd()
 
-        return wrapState({
+        return {
           ...state,
           ...updatedHistory
-        })
+        }
     }
   }
 }
@@ -294,13 +282,6 @@ export function includeAction (rawActions) {
   return (action) => actions.indexOf(action.type) >= 0
 }
 // /includeAction
-
-// deprecated ifAction helper
-export function ifAction (rawActions) {
-  console.error('Deprecation Warning: Please change `ifAction` to `includeAction`')
-  return includeAction(rawActions)
-}
-// /ifAction
 
 // excludeAction helper
 export function excludeAction (rawActions = []) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -31,22 +31,17 @@ describe('Undoable', () => {
       }
     }
     mockUndoableReducer = undoable(countReducer, undoConfig)
+    // { past: [], present: 0, future: [] }
     mockInitialState = mockUndoableReducer(void 0, {})
+    // { past: [ 0 ], present: 1, future: [] }
     incrementedState = mockUndoableReducer(mockInitialState, { type: 'INCREMENT' })
-  })
-
-  it('should wrap its old history', () => {
-    let doubleIncrementedState = mockUndoableReducer(incrementedState, { type: 'INCREMENT' })
-
-    expect(incrementedState.history.history).to.deep.equal(mockInitialState.history)
-    expect(doubleIncrementedState.history.history).to.deep.equal(incrementedState.history)
   })
 
   it('should not record unwanted actions', () => {
     let decrementedState = mockUndoableReducer(mockInitialState, { type: 'DECREMENT' })
 
-    expect(decrementedState.history.past).to.deep.equal(mockInitialState.history.past)
-    expect(decrementedState.history.future).to.deep.equal(mockInitialState.history.future)
+    expect(decrementedState.past).to.deep.equal([])
+    expect(decrementedState.future).to.deep.equal([])
   })
   it('should reset upon init actions', () => {
     let doubleIncrementedState = mockUndoableReducer(incrementedState, { type: 'INCREMENT' })
@@ -79,7 +74,6 @@ describe('Undoable', () => {
     it('should do nothing if \'past\' is empty', () => {
       let undoInitialState = mockUndoableReducer(mockInitialState, ActionCreators.undo())
       expect(mockInitialState.past.length).to.equal(0)
-      expect(undoInitialState.history).to.deep.equal(mockInitialState)
       expect(undoInitialState.present).to.deep.equal(mockInitialState.present)
     })
   })
@@ -107,9 +101,7 @@ describe('Undoable', () => {
     })
     it('should do nothing if \'future\' is empty', () => {
       let secondRedoState = mockUndoableReducer(redoState, ActionCreators.redo())
-
       expect(redoState.future.length).to.equal(0)
-      expect(secondRedoState.history).to.deep.equal(redoState)
       expect(secondRedoState.present).to.deep.equal(redoState.present)
     })
   })


### PR DESCRIPTION
simple modify to remove the history property, now the state look like this:
``` diff
{
  past: [...pastStatesHere...],
  present: {...currentStateHere...},
  future: [...futureStatesHere...]
- history:  // removed
}
```
btw, I update the test case. Please review the code, thank you！