### PR TITLE
Implement `CLEAR_HISTORY` Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ store.dispatch(ActionCreators.redo()) // redo the last action
 
 store.dispatch(ActionCreators.jumpToPast(index)) // jump to requested index in the past[] array
 store.dispatch(ActionCreators.jumpToFuture(index)) // jump to requested index in the future[] array
+
+store.dispatch(ActionCreators.clearHistory()) // Remove all items from past[] and future[] arrays
 ```
 
 
@@ -123,6 +125,8 @@ undoable(reducer, {
 
   jumpToPastType: ActionTypes.JUMP_TO_PAST, // define custom action type for this jumpToPast action
   jumpToFutureType: ActionTypes.JUMP_TO_FUTURE, // define custom action type for this jumpToFuture action
+
+  clearHistoryType: ActionTypes.CLEAR_HISTORY, // define custom action type for this clearHistory action
 
   initialState: undefined, // initial state (e.g. for loading)
   initTypes: ['@@redux/INIT', '@@INIT'] // history will be (re)set upon init action type

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,8 @@ export const ActionTypes = {
   UNDO: '@@redux-undo/UNDO',
   REDO: '@@redux-undo/REDO',
   JUMP_TO_FUTURE: '@@redux-undo/JUMP_TO_FUTURE',
-  JUMP_TO_PAST: '@@redux-undo/JUMP_TO_PAST'
+  JUMP_TO_PAST: '@@redux-undo/JUMP_TO_PAST',
+  CLEAR_HISTORY: '@@redux-undo/CLEAR_HISTORY'
 }
 // /action types
 
@@ -49,6 +50,9 @@ export const ActionCreators = {
   },
   jumpToPast (index) {
     return { type: ActionTypes.JUMP_TO_PAST, index }
+  },
+  clearHistory () {
+    return { type: ActionTypes.CLEAR_HISTORY }
   }
 }
 // /action creators
@@ -191,7 +195,8 @@ export default function undoable (reducer, rawConfig = {}) {
     undoType: rawConfig.undoType || ActionTypes.UNDO,
     redoType: rawConfig.redoType || ActionTypes.REDO,
     jumpToPastType: rawConfig.jumpToPastType || ActionTypes.JUMP_TO_PAST,
-    jumpToFutureType: rawConfig.jumpToFutureType || ActionTypes.JUMP_TO_FUTURE
+    jumpToFutureType: rawConfig.jumpToFutureType || ActionTypes.JUMP_TO_FUTURE,
+    clearHistoryType: rawConfig.clearHistoryType || ActionTypes.CLEAR_HISTORY
   }
   config.history = rawConfig.initialHistory || createHistory(config.initialState)
 
@@ -224,6 +229,12 @@ export default function undoable (reducer, rawConfig = {}) {
       case config.jumpToFutureType:
         res = jumpToFuture(state, action.index)
         debug('after jumpToFuture', res)
+        debugEnd()
+        return res
+
+      case config.clearHistoryType:
+        res = createHistory(state.present)
+        debug('cleared history', res)
         debugEnd()
         return res
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -110,4 +110,18 @@ describe('Undoable', () => {
       }
     })
   })
+  describe('Clear History', () => {
+    let clearedState
+
+    before('perform a clearHistory action', () => {
+      clearedState = mockUndoableReducer(incrementedState, ActionCreators.clearHistory())
+    })
+    it('should clear future and past', () => {
+      expect(clearedState.past.length).to.equal(0)
+      expect(clearedState.future.length).to.equal(0)
+    })
+    it('should preserve the present value', () => {
+      expect(clearedState.present).to.equal(incrementedState.present)
+    })
+  })
 })


### PR DESCRIPTION
As requested in #38, this change provides an action for removing all items from `past` and `future`.