### PR TITLE
Create store fixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,6 @@ export default function undoable (reducer, rawConfig = {}) {
     let res
     switch (action.type) {
       case undefined:
-      case '@@redux/INIT':
         return state
 
       case config.undoType:
@@ -251,7 +250,10 @@ export default function undoable (reducer, rawConfig = {}) {
           }
         }
 
-        const updatedHistory = insert(state, res, config.limit)
+        const updatedHistory = (state.present === res)
+          ? state
+          : insert(state, res, config.limit)
+
         debug('after insert', {history: updatedHistory, free: config.limit - length(updatedHistory)})
         debugEnd()
         return updatedHistory

--- a/src/index.js
+++ b/src/index.js
@@ -73,15 +73,6 @@ function insert (history, state, limit) {
   const { past, present } = history
   const historyOverflow = limit && length(history) >= limit
 
-  if (present === undefined) {
-    // init history
-    return {
-      past: [],
-      present: state,
-      future: []
-    }
-  }
-
   return {
     past: [
       ...past.slice(historyOverflow ? 1 : 0),
@@ -201,10 +192,6 @@ export default function undoable (reducer, rawConfig = {}) {
     clearHistoryType: rawConfig.clearHistoryType || ActionTypes.CLEAR_HISTORY
   }
   config.history = rawConfig.initialHistory || createHistory(config.initialState || reducer(undefined, {}))
-
-  if (config.initTypes.length === 0) {
-    console.warn('redux-undo: supply at least one action type in initTypes to ensure initial state')
-  }
 
   return (state = config.history, action = {}) => {
     debugStart(action, state)

--- a/src/index.js
+++ b/src/index.js
@@ -191,7 +191,7 @@ export default function undoable (reducer, rawConfig = {}) {
 
   const config = {
     initialState: rawConfig.initialState,
-    initTypes: parseActions(rawConfig.initTypes, ['@@redux/INIT', '@@INIT']),
+    initTypes: parseActions(rawConfig.initTypes, ['@@redux-undo/INIT']),
     limit: rawConfig.limit,
     filter: rawConfig.filter || (() => true),
     undoType: rawConfig.undoType || ActionTypes.UNDO,
@@ -211,6 +211,7 @@ export default function undoable (reducer, rawConfig = {}) {
     let res
     switch (action.type) {
       case undefined:
+      case '@@redux/INIT':
         return state
 
       case config.undoType:

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -36,7 +36,7 @@ const testConfigFour = {
   initialState: null,
   initialHistory: {
     past: [5, {}, 3, null, 1],
-    present: undefined,
+    present: Math.pow(2, 32),
     future: []
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,5 +1,6 @@
-let { expect } = require('chai')
-let { default: undoable, ActionCreators, excludeAction } = require('../src/index')
+const { expect } = require('chai')
+const { default: undoable, ActionCreators, excludeAction } = require('../src/index')
+const Redux = require('redux')
 
 const excludedActionsOne = ['DECREMENT']
 const testConfigOne = {
@@ -110,7 +111,7 @@ function runTestWithConfig (testConfig, label) {
           return
         }
       } else {
-        reInitializedState = mockUndoableReducer(incrementedState, { type: '@@INIT' })
+        reInitializedState = mockUndoableReducer(incrementedState, { type: '@@redux-undo/INIT' })
       }
 
       if (testConfig.initialHistory) {
@@ -262,6 +263,27 @@ function runTestWithConfig (testConfig, label) {
       })
       it('should preserve the present value', () => {
         expect(clearedState.present).to.equal(incrementedState.present)
+      })
+    })
+    describe('Relation to Redux', () => {
+      it('should be able to create a store', () => {
+        const store = Redux.createStore(mockUndoableReducer)
+        if (testConfig.initialHistory) {
+          expect(store.getState()).to.deep.equal(testConfig.initialHistory)
+        } else if (testConfig.initialState !== undefined) {
+          expect(store.getState().present).to.deep.equal(testConfig.initialState)
+        } else {
+          expect(store.getState()).to.deep.equal(mockUndoableReducer(undefined, {}))
+        }
+      })
+      it('should accept the initialState from `createStore`', () => {
+        const rehydratingState = {
+          past: ['a', 'b', 'c'],
+          present: 'd',
+          future: ['e', 'f']
+        }
+        const store = Redux.createStore(mockUndoableReducer, rehydratingState)
+        expect(store.getState()).to.deep.equal(rehydratingState)
       })
     })
   })


### PR DESCRIPTION
Isolated create store fixes

@pl12133 commited: 

* Pass through `@@redux/INIT` so that `createStore` can properly set the `initialState` of the reducer.
* Add tests for `undoable`s relationship with the Redux store.
* The reducer no longer requires an `initType` to ensure an `initialState`. `state.present` should never become undefined.
* Avoid parsing `@@redux/INIT`, only call `insert` if a reducer produces a distinct state.
