### PR TITLE
Addded more support for initialState in createStore without a history

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -250,11 +250,19 @@ export default function undoable (reducer, rawConfig = {}) {
           }
         }
 
-        const updatedHistory = (state.present === res)
-          ? state
-          : insert(state, res, config.limit)
+        let updatedHistory
+        if (typeof state.present === 'undefined') {
+          updatedHistory = createHistory(state)
+          debug('create history on init')
+        } else if (state.present === res) {
+          updatedHistory = state
+          debug('not inserted, state is unchanged')
+        } else {
+          updatedHistory = insert(state, res, config.limit)
+          debug('inserted new state into history')
+        }
 
-        debug('after insert', {history: updatedHistory, free: config.limit - length(updatedHistory)})
+        debug('history: ', updatedHistory, ' free: ', config.limit - length(updatedHistory))
         debugEnd()
         return updatedHistory
     }

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,16 @@ function length (history) {
 }
 // /length
 
+// isHistory: check for a valid history object
+function isHistory (history) {
+  return typeof history.present !== 'undefined' &&
+    typeof history.future !== 'undefined' &&
+    typeof history.past !== 'undefined' &&
+    Array.isArray(history.future) &&
+    Array.isArray(history.past)
+}
+// /isHistory
+
 // insert: insert `state` into history, which means adding the current state
 //         into `past`, setting the new `state` as `present` and erasing
 //         the `future`.
@@ -251,7 +261,7 @@ export default function undoable (reducer, rawConfig = {}) {
         }
 
         let updatedHistory
-        if (typeof state.present === 'undefined') {
+        if (!isHistory(state)) {
           updatedHistory = createHistory(state)
           debug('create history on init')
         } else if (state.present === res) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -285,6 +285,15 @@ function runTestWithConfig (testConfig, label) {
         const store = Redux.createStore(mockUndoableReducer, rehydratingState)
         expect(store.getState()).to.deep.equal(rehydratingState)
       })
+      it('should accept the initialState from `createStore` without a history', () => {
+        const reHydratingState = {'a': 'b', 'c': [1, 2, 3], 'e': {'foo': 'bbb'}}
+        const store = Redux.createStore(mockUndoableReducer, reHydratingState)
+        expect(store.getState()).to.deep.equal({
+          past: [],
+          present: {'a': 'b', 'c': [1, 2, 3], 'e': {'foo': 'bbb'}},
+          future: []
+        })
+      })
     })
   })
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -277,13 +277,13 @@ function runTestWithConfig (testConfig, label) {
         }
       })
       it('should accept the initialState from `createStore`', () => {
-        const rehydratingState = {
+        const reHydratingState = {
           past: ['a', 'b', 'c'],
           present: 'd',
           future: ['e', 'f']
         }
-        const store = Redux.createStore(mockUndoableReducer, rehydratingState)
-        expect(store.getState()).to.deep.equal(rehydratingState)
+        const store = Redux.createStore(mockUndoableReducer, reHydratingState)
+        expect(store.getState()).to.deep.equal(reHydratingState)
       })
       it('should accept the initialState from `createStore` without a history', () => {
         const reHydratingState = {'a': 'b', 'c': [1, 2, 3], 'e': {'foo': 'bbb'}}
@@ -291,6 +291,16 @@ function runTestWithConfig (testConfig, label) {
         expect(store.getState()).to.deep.equal({
           past: [],
           present: {'a': 'b', 'c': [1, 2, 3], 'e': {'foo': 'bbb'}},
+          future: []
+        })
+      })
+      it('should accept the initialState from `createStore` and should not fain on an initialState that looks like our history object', () => {
+        // previously failing case
+        const reHydratingState = {'present': 0}
+        const store = Redux.createStore(mockUndoableReducer, reHydratingState)
+        expect(store.getState()).to.deep.equal({
+          past: [],
+          present: {'present': 0},
           future: []
         })
       })


### PR DESCRIPTION
On Gitter @pl12133 wrote:

> the user would have to pass in a proper history object to Redux.createStore, like 
>  `{ past: [], present: 0, future: [] }`
> i think its fine to do it that way

I think it would be preferable to not change what users have to provide to Redux.createStore having to provide a history object makes it just a little harde (and is extra documentation in the redux-undo readme.

Having to provide a history object indeed helps users get a better understanding of what is going on though, but this enables both and saves boilerplate :)