### PR TITLE
Change `filter` signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,26 +180,9 @@ const store = createStore(undoable(counter), {foo: 'bar'});
 ### Filtering Actions
 
 If you don't want to include every action in the undo/redo history, you can
-pass a function to `undoable` like this:
-
-```js
-undoable(reducer, {
-  filter: function filterActions(action, currentState, previousState) {
-    return action.type === SOME_ACTION; // only add to history if action is SOME_ACTION
-  }
-})
-
-// or you could do...
-
-undoable(reducer, {
-  filter: function filterState(action, currentState, previousState) {
-    return currentState !== previousState; // only add to history if state changed
-  }
-})
-```
-
-Or you can use the `distinctState`, `includeAction` and `excludeAction` helpers,
-which should be imported like this:
+add a `filter` function to `undoable`. `redux-undo` provides you with the
+`distinctState`, `includeAction` and `excludeAction` helpers for basic filtering.
+They should be imported like this:
 
 ```js
 import undoable, { distinctState, includeAction, excludeAction } from 'redux-undo';
@@ -214,13 +197,32 @@ undoable(reducer, { filter: excludeAction(SOME_ACTION) })
 // or you could do...
 
 undoable(reducer, { filter: distinctState() })
-```
 
-... they even support Arrays:
+// they even support Arrays:
 
-```js
 undoable(reducer, { filter: includeAction([SOME_ACTION, SOME_OTHER_ACTION]) })
 undoable(reducer, { filter: excludeAction([SOME_ACTION, SOME_OTHER_ACTION]) })
+```
+
+If you want to create your own filter, pass in a function with the signature
+`(action, currentState, previousHistory)`. For example:
+
+```js
+undoable(reducer, {
+  filter: function filterActions(action, currentState, previousHistory) {
+    return action.type === SOME_ACTION; // only add to history if action is SOME_ACTION
+  }
+})
+
+// The entire `history` state is available to your filter, so you can make
+// decisions based on past or future states:
+
+undoable(reducer, {
+  filter: function filterState(action, currentState, previousHistory) {
+    let { past, present, future } = previousHistory;
+    return future.length === 0; // only add to history if future is empty
+  }
+})
 ```
 
 ### Ignoring Actions

--- a/README.md
+++ b/README.md
@@ -133,13 +133,7 @@ undoable(reducer, {
 
   clearHistoryType: ActionTypes.CLEAR_HISTORY, // define custom action type for this clearHistory action
 
-  initialState: undefined, // initial state (e.g. for loading)
   initTypes: ['@@redux-undo/INIT'] // history will be (re)set upon init action type
-  initialHistory: { // initial history (e.g. for loading)
-    past: [],
-    present: config.initialState,
-    future: []
-  },
 
   debug: false, // set to `true` to turn on debugging
 })
@@ -150,19 +144,36 @@ the whole redux-undo library, use [redux-recycle](https://github.com/omnidan/red
 
 #### Initial State and History
 
-It's possible to provide an `initialState` or `initialHistory` but redux-undo also works with an initial state on our existing redux store. This way you don't have to pass an initialHistory in your undable config if you're already setting some initial state on your store:
+You can use your redux store to set an initial history for your undoable reducers: 
 
 ```js
 
 import { createStore } from 'redux';
 
-const initialStoreState = {
+const initialHistory = {
   past: [0, 1, 2, 3],
   present: 4,
   future: [5, 6, 7]
 }
 
-const store = createStore(undoable(counter), initialStoreState);
+const store = createStore(undoable(counter), initialHistory);
+
+```
+
+Or just set the current state like you're used to with Redux. Redux-undo will create the history for you: 
+
+```js
+
+import { createStore } from 'redux';
+
+const store = createStore(undoable(counter), {foo: 'bar'});
+
+// will make the state look like this:
+{
+  past: [],
+  present: {foo: 'bar'},
+  future: []
+}
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ perform undo/redo operations on your state:
 store.dispatch(ActionCreators.undo()) // undo the last action
 store.dispatch(ActionCreators.redo()) // redo the last action
 
+store.dispatch(ActionCreators.jump(-2)) // undo 2 steps
+store.dispatch(ActionCreators.jump(5)) // redo 5 steps
+
 store.dispatch(ActionCreators.jumpToPast(index)) // jump to requested index in the past[] array
 store.dispatch(ActionCreators.jumpToFuture(index)) // jump to requested index in the future[] array
 
@@ -122,6 +125,8 @@ undoable(reducer, {
 
   undoType: ActionTypes.UNDO, // define a custom action type for this undo action
   redoType: ActionTypes.REDO, // define a custom action type for this redo action
+
+  jumpType: ActionTypes.JUMP, // define custom action type for this jump action
 
   jumpToPastType: ActionTypes.JUMP_TO_PAST, // define custom action type for this jumpToPast action
   jumpToFutureType: ActionTypes.JUMP_TO_FUTURE, // define custom action type for this jumpToFuture action

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-undo",
-  "version": "1.0.0-beta3",
+  "version": "1.0.0-beta4",
   "description": "simple undo/redo functionality for redux state containers",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -278,14 +278,12 @@ export default function undoable (reducer, rawConfig = {}) {
           return config.history
         }
 
-        if (config.filter && typeof config.filter === 'function') {
-          if (!config.filter(action, res, history.present)) {
-            debug('filter prevented action, not storing it')
-            debugEnd()
-            return {
-              ...history,
-              present: res
-            }
+        if (typeof config.filter === 'function' && !config.filter(action, res, history)) {
+          debug('filter prevented action, not storing it')
+          debugEnd()
+          return {
+            ...history,
+            present: res
           }
         }
 
@@ -316,7 +314,7 @@ export function isHistory (history) {
 
 // distinctState helper
 export function distinctState () {
-  return (action, currentState, previousState) => currentState !== previousState
+  return (action, currentState, { past, present, future }) => currentState !== present
 }
 // /distinctState
 

--- a/src/index.js
+++ b/src/index.js
@@ -134,6 +134,7 @@ function redo (history) {
 // jumpToFuture: jump to requested index in future history
 function jumpToFuture (history, index) {
   if (index === 0) return redo(history)
+  if (index < 0 || index >= history.future.length) return history
 
   const { past, present, future } = history
 
@@ -149,6 +150,7 @@ function jumpToFuture (history, index) {
 // jumpToPast: jump to requested index in past history
 function jumpToPast (history, index) {
   if (index === history.past.length - 1) return undo(history)
+  if (index < 0 || index >= history.past.length) return history
 
   const { past, present, future } = history
 
@@ -198,16 +200,19 @@ export default function undoable (reducer, rawConfig = {}) {
     jumpToFutureType: rawConfig.jumpToFutureType || ActionTypes.JUMP_TO_FUTURE,
     clearHistoryType: rawConfig.clearHistoryType || ActionTypes.CLEAR_HISTORY
   }
-  config.history = rawConfig.initialHistory || createHistory(config.initialState)
+  config.history = rawConfig.initialHistory || createHistory(config.initialState || reducer(undefined, {}))
 
   if (config.initTypes.length === 0) {
     console.warn('redux-undo: supply at least one action type in initTypes to ensure initial state')
   }
 
-  return (state, action) => {
+  return (state = config.history, action = {}) => {
     debugStart(action, state)
     let res
     switch (action.type) {
+      case undefined:
+        return state
+
       case config.undoType:
         res = undo(state)
         debug('after undo', res)
@@ -244,7 +249,7 @@ export default function undoable (reducer, rawConfig = {}) {
         if (config.initTypes.some((actionType) => actionType === action.type)) {
           debug('reset history due to init action')
           debugEnd()
-          return createHistory(res)
+          return config.history
         }
 
         if (config.filter && typeof config.filter === 'function') {
@@ -258,8 +263,7 @@ export default function undoable (reducer, rawConfig = {}) {
           }
         }
 
-        const history = (state && state.present !== undefined) ? state : config.history
-        const updatedHistory = insert(history, res, config.limit)
+        const updatedHistory = insert(state, res, config.limit)
         debug('after insert', {history: updatedHistory, free: config.limit - length(updatedHistory)})
         debugEnd()
         return updatedHistory

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -320,6 +320,56 @@ function runTestWithConfig (testConfig, label) {
         const store = Redux.createStore(mockUndoableReducer, reHydratingState)
         expect(store.getState()).to.deep.equal(reHydratingState)
       })
+
+      it('should accept the initialState from `createStore` and should increment', () => {
+        const reHydratingState = {
+          past: [0, 1, 2],
+          present: 3,
+          future: [4, 5]
+        }
+        const store = Redux.createStore(mockUndoableReducer, reHydratingState)
+        store.dispatch({ type: 'INCREMENT' })
+        expect(store.getState()).to.deep.equal({
+          past: [0, 1, 2, 3],
+          present: 4,
+          future: []
+        })
+      })
+
+      it('should accept the initialState from `createStore` and reset upon init actions', () => {
+        const reHydratingState = {
+          past: [0, 1, 2],
+          present: 3,
+          future: [4, 5]
+        }
+        const incrementedHistory = {
+          past: [0, 1, 2, 3],
+          present: 4,
+          future: []
+        }
+        const store = Redux.createStore(mockUndoableReducer, reHydratingState)
+        expect(store.getState()).to.deep.equal(reHydratingState)
+
+        store.dispatch({ type: 'INCREMENT' })
+
+        // This will also fail in some cases, see previous test
+         expect(store.getState()).to.deep.equal(incrementedHistory)
+
+        if (testConfig.initTypes) {
+          if (testConfig.initTypes.length) {
+            store.dispatch({ type: testConfig.initTypes[0] })
+            expect(store.getState()).to.deep.equal(reHydratingState)
+          } else {
+            // No init actions exist, init should have no effect
+            store.dispatch({ type: '@@redux-undo/INIT' })
+            expect(store.getState()).to.deep.equal(incrementedHistory)
+          }
+        } else {
+          store.dispatch({ type: '@@redux-undo/INIT' })
+          expect(store.getState()).to.deep.equal(reHydratingState)
+        }
+      })
+
       it('should accept the initialState from `createStore` without a history', () => {
         const reHydratingState = {'a': 'b', 'c': [1, 2, 3], 'e': {'foo': 'bbb'}}
         const store = Redux.createStore(mockUndoableReducer, reHydratingState)
@@ -329,6 +379,49 @@ function runTestWithConfig (testConfig, label) {
           future: []
         })
       })
+
+      // More of the same, re-enable and test if others are fixed
+      //it('should accept the initialState from `createStore` without a history and should increment', () => {
+      //  const reHydratingState = 0
+      //  const store = Redux.createStore(mockUndoableReducer, reHydratingState)
+      //  store.dispatch({ type: 'INCREMENT' })
+      //  expect(store.getState()).to.deep.equal({
+      //    past: [100],
+      //    present: 101,
+      //    future: []
+      //  })
+      //})
+      //
+      //it('should accept the initialState from `createStore` without a history and reset upon init actions', () => {
+      //  const reHydratingState = 100
+      //  const incrementedHistory = {
+      //    past: [100],
+      //    present: 101,
+      //    future: []
+      //  }
+      //  const store = Redux.createStore(mockUndoableReducer, reHydratingState)
+      //  expect(store.getState()).to.deep.equal(reHydratingState)
+      //
+      //  store.dispatch({ type: 'INCREMENT' })
+      //
+      //  // This will also fail in some cases, see previous test
+      //  expect(store.getState()).to.deep.equal(incrementedHistory)
+      //
+      //  if (testConfig.initTypes) {
+      //    if (testConfig.initTypes.length) {
+      //      store.dispatch({ type: testConfig.initTypes[0] })
+      //      expect(store.getState()).to.deep.equal(reHydratingState)
+      //    } else {
+      //      // No init actions exist, init should have no effect
+      //      store.dispatch({ type: '@@redux-undo/INIT' })
+      //      expect(store.getState()).to.deep.equal(incrementedHistory)
+      //    }
+      //  } else {
+      //    store.dispatch({ type: '@@redux-undo/INIT' })
+      //    expect(store.getState()).to.deep.equal(reHydratingState)
+      //  }
+      //})
+
       it('should accept the initialState from `createStore` and should not fain on an initialState that looks like our history object', () => {
         // previously failing case
         const reHydratingState = {'present': 0}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,127 +1,268 @@
 let { expect } = require('chai')
-let { default: undoable, ActionCreators } = require('../src/index')
+let { default: undoable, ActionCreators, excludeAction } = require('../src/index')
 
-describe('Undoable', () => {
-  let mockUndoableReducer
-  let mockInitialState
-  let incrementedState
+const excludedActionsOne = ['DECREMENT']
+const testConfigOne = {
+  limit: 100,
+  initTypes: 'RE-INITIALIZE',
+  initialHistory: {
+    past: [0, 1, 2, 3],
+    present: 4,
+    future: [5, 6, 7]
+  },
+  FOR_TEST_ONLY_excludedActions: excludedActionsOne,
+  filter: excludeAction(excludedActionsOne)
+}
 
-  before('setup mock reducers and states', () => {
-    let countInitialState = 0
-    let countReducer = (state = countInitialState, action = {}) => {
-      switch (action.type) {
-        case 'INCREMENT':
-          return state + 1
-        case 'DECREMENT':
-          return state - 1
-        default:
-          return state
-      }
-    }
-    let undoConfig = {
-      limit: 100,
-      initTypes: 'RE-INITIALIZE',
-      initialHistory: {
-        past: [0, 1, 2, 3],
-        present: 4,
-        future: [5, 6, 7]
-      },
-      filter: function (action) {
+const testConfigTwo = {
+  limit: 200,
+  initialState: 100
+}
+
+const testConfigThree = {
+  limit: 1024,
+  initTypes: 'RE-INITIALIZE',
+  initialState: -1,
+  initialHistory: {
+    past: [123],
+    present: 5,
+    future: [-1, -2, -3]
+  }
+}
+const testConfigFour = {
+  limit: -1,
+  initTypes: [],
+  initialState: null,
+  initialHistory: {
+    past: [5, {}, 3, null, 1],
+    present: undefined,
+    future: []
+  }
+}
+
+runTestWithConfig({}, 'Default config')
+runTestWithConfig(testConfigOne, 'Initial History and Filter (Exclude Actions)')
+runTestWithConfig(testConfigTwo, 'Initial State equals 100')
+runTestWithConfig(testConfigThree, 'Initial State and Initial History')
+runTestWithConfig(testConfigFour, 'Erroneous configuration')
+
+// Test undoable reducers as a function of a configuration object
+// `label` describes the nature of the configuration object used to run a test
+function runTestWithConfig (testConfig, label) {
+  describe('Undoable: ' + label, () => {
+    testConfig.initTypes = (Array.isArray(testConfig.initTypes) || testConfig.initTypes === undefined) ? testConfig.initTypes : [testConfig.initTypes]
+    let mockUndoableReducer
+    let mockInitialState
+    let incrementedState
+    let countReducer
+
+    before('setup mock reducers and states', () => {
+      let countInitialState = 0
+      countReducer = (state = countInitialState, action = {}) => {
         switch (action.type) {
+          case 'INCREMENT':
+            return state + 1
           case 'DECREMENT':
-            return false
+            return state - 1
           default:
-            return true
+            return state
         }
       }
-    }
-    mockUndoableReducer = undoable(countReducer, undoConfig)
-    mockInitialState = mockUndoableReducer(void 0, {})
-    incrementedState = mockUndoableReducer(mockInitialState, { type: 'INCREMENT' })
-  })
+      mockUndoableReducer = undoable(countReducer, testConfig)
+      mockInitialState = mockUndoableReducer(undefined, {})
+      incrementedState = mockUndoableReducer(mockInitialState, { type: 'INCREMENT' })
+      console.info('  Beginning Test! Good luck!')
+      console.info('    mockInitialState:', mockInitialState)
+      console.info('    incrementedState:', incrementedState)
+      console.info('')
+    })
 
-  it('should not record unwanted actions', () => {
-    let decrementedState = mockUndoableReducer(mockInitialState, { type: 'DECREMENT' })
-
-    expect(decrementedState.past).to.deep.equal(mockInitialState.past)
-    expect(decrementedState.future).to.deep.equal(mockInitialState.future)
-  })
-  it('should reset upon init actions', () => {
-    let doubleIncrementedState = mockUndoableReducer(incrementedState, { type: 'INCREMENT' })
-    let reInitializedState = mockUndoableReducer(doubleIncrementedState, { type: 'RE-INITIALIZE' })
-
-    expect(reInitializedState.past.length).to.equal(0)
-    expect(reInitializedState.future.length).to.equal(0)
-  })
-
-  describe('Undo', () => {
-    let undoState
-    before('perform an undo action', () => {
-      undoState = mockUndoableReducer(incrementedState, ActionCreators.undo())
-    })
-    it('should change present state back by one action', () => {
-      expect(undoState.present).to.equal(mockInitialState.present)
-    })
-    it('should change present state to last element of \'past\'', () => {
-      expect(undoState.present).to.equal(incrementedState.past[incrementedState.past.length - 1])
-    })
-    it('should add a new element to \'future\' from last state', () => {
-      expect(undoState.future[0]).to.equal(incrementedState.present)
-    })
-    it('should decrease length of \'past\' by one', () => {
-      expect(undoState.past.length).to.equal(incrementedState.past.length - 1)
-    })
-    it('should increase length of \'future\' by one', () => {
-      expect(undoState.future.length).to.equal(incrementedState.future.length + 1)
-    })
-    it('should do nothing if \'past\' is empty', () => {
-      let undoInitialState = mockUndoableReducer(mockInitialState, ActionCreators.undo())
-      if (!mockInitialState.past.length) {
-        expect(undoInitialState.present).to.deep.equal(mockInitialState.present)
+    it('should be initialized with the value of `initialHistory`', () => {
+      if (testConfig.initialHistory) {
+        expect(mockInitialState).to.deep.equal(testConfig.initialHistory)
       }
     })
-  })
-  describe('Redo', () => {
-    let undoState
-    let redoState
-    before('perform an undo action then a redo action', () => {
-      undoState = mockUndoableReducer(incrementedState, ActionCreators.undo())
-      redoState = mockUndoableReducer(undoState, ActionCreators.redo())
-    })
-    it('should change present state to equal state before undo', () => {
-      expect(redoState.present).to.equal(incrementedState.present)
-    })
-    it('should change present state to first element of \'future\'', () => {
-      expect(redoState.present).to.equal(undoState.future[0])
-    })
-    it('should add a new element to \'past\' from last state', () => {
-      expect(redoState.past[redoState.past.length - 1]).to.equal(undoState.present)
-    })
-    it('should decrease length of \'future\' by one', () => {
-      expect(redoState.future.length).to.equal(undoState.future.length - 1)
-    })
-    it('should increase length of \'past\' by one', () => {
-      expect(redoState.past.length).to.equal(undoState.past.length + 1)
-    })
-    it('should do nothing if \'future\' is empty', () => {
-      let secondRedoState = mockUndoableReducer(redoState, ActionCreators.redo())
-      if (!redoState.future.length) {
-        expect(secondRedoState.present).to.deep.equal(redoState.present)
+    it('should be initialized with the value of `initialState` if there is no `initialHistory', () => {
+      if (!testConfig.initialHistory && testConfig.initialState !== undefined) {
+        expect(mockInitialState.present).to.equal(testConfig.initialState)
       }
     })
-  })
-  describe('Clear History', () => {
-    let clearedState
+    it('should be initialized with the value of the default `initialState` of the reducer if there is no `initialState` or `initialHistory', () => {
+      if (!testConfig.initialHistory && testConfig.initialState === undefined) {
+        expect(mockInitialState.present).to.equal(countReducer())
+      }
+    })
+    it('should not record unwanted actions', () => {
+      if (testConfig.FOR_TEST_ONLY_excludedActions && testConfig.FOR_TEST_ONLY_excludedActions[0]) {
+        let decrementedState = mockUndoableReducer(mockInitialState, { type: testConfig.FOR_TEST_ONLY_excludedActions[0] })
 
-    before('perform a clearHistory action', () => {
-      clearedState = mockUndoableReducer(incrementedState, ActionCreators.clearHistory())
+        expect(decrementedState.past).to.deep.equal(mockInitialState.past)
+        expect(decrementedState.future).to.deep.equal(mockInitialState.future)
+      }
     })
-    it('should clear future and past', () => {
-      expect(clearedState.past.length).to.equal(0)
-      expect(clearedState.future.length).to.equal(0)
+    it('should reset upon init actions', () => {
+      let reInitializedState
+      if (testConfig.initTypes) {
+        if (testConfig.initTypes.length) {
+          reInitializedState = mockUndoableReducer(incrementedState, { type: testConfig.initTypes[0] })
+        } else {
+          // No init actions exist
+          return
+        }
+      } else {
+        reInitializedState = mockUndoableReducer(incrementedState, { type: '@@INIT' })
+      }
+
+      if (testConfig.initialHistory) {
+        expect(reInitializedState.past.length).to.equal(testConfig.initialHistory.past.length)
+        expect(reInitializedState.future.length).to.equal(testConfig.initialHistory.future.length)
+      } else {
+        expect(reInitializedState.past.length).to.equal(0)
+        expect(reInitializedState.future.length).to.equal(0)
+      }
     })
-    it('should preserve the present value', () => {
-      expect(clearedState.present).to.equal(incrementedState.present)
+
+    describe('Undo', () => {
+      let undoState
+      before('perform an undo action', () => {
+        undoState = mockUndoableReducer(incrementedState, ActionCreators.undo())
+      })
+      it('should change present state back by one action', () => {
+        if (testConfig.limit >= 0) {
+          expect(undoState.present).to.equal(mockInitialState.present)
+        }
+      })
+      it('should change present state to last element of \'past\'', () => {
+        if (testConfig.limit >= 0) {
+          expect(undoState.present).to.equal(incrementedState.past[incrementedState.past.length - 1])
+        }
+      })
+      it('should add a new element to \'future\' from last state', () => {
+        if (testConfig.limit >= 0) {
+          expect(undoState.future[0]).to.equal(incrementedState.present)
+        }
+      })
+      it('should decrease length of \'past\' by one', () => {
+        if (testConfig.limit >= 0) {
+          expect(undoState.past.length).to.equal(incrementedState.past.length - 1)
+        }
+      })
+      it('should increase length of \'future\' by one', () => {
+        if (testConfig.limit >= 0) {
+          expect(undoState.future.length).to.equal(incrementedState.future.length + 1)
+        }
+      })
+      it('should do nothing if \'past\' is empty', () => {
+        let undoInitialState = mockUndoableReducer(mockInitialState, ActionCreators.undo())
+        if (!mockInitialState.past.length) {
+          expect(undoInitialState.present).to.deep.equal(mockInitialState.present)
+        }
+      })
+    })
+    describe('Redo', () => {
+      let undoState
+      let redoState
+      before('perform an undo action then a redo action', () => {
+        undoState = mockUndoableReducer(incrementedState, ActionCreators.undo())
+        redoState = mockUndoableReducer(undoState, ActionCreators.redo())
+      })
+      it('should change present state to equal state before undo', () => {
+        expect(redoState.present).to.equal(incrementedState.present)
+      })
+      it('should change present state to first element of \'future\'', () => {
+        if (testConfig.limit >= 0) {
+          expect(redoState.present).to.equal(undoState.future[0])
+        }
+      })
+      it('should add a new element to \'past\' from last state', () => {
+        if (testConfig.limit >= 0) {
+          expect(redoState.past[redoState.past.length - 1]).to.equal(undoState.present)
+        }
+      })
+      it('should decrease length of \'future\' by one', () => {
+        if (testConfig.limit >= 0) {
+          expect(redoState.future.length).to.equal(undoState.future.length - 1)
+        }
+      })
+      it('should increase length of \'past\' by one', () => {
+        if (testConfig.limit >= 0) {
+          expect(redoState.past.length).to.equal(undoState.past.length + 1)
+        }
+      })
+      it('should do nothing if \'future\' is empty', () => {
+        let secondRedoState = mockUndoableReducer(redoState, ActionCreators.redo())
+        if (!redoState.future.length) {
+          expect(secondRedoState.present).to.deep.equal(redoState.present)
+        }
+      })
+    })
+    describe('JumpToPast', () => {
+      const jumpToPastIndex = 0
+      let jumpToPastState
+      before('perform a jumpToPast action', () => {
+        jumpToPastState = mockUndoableReducer(incrementedState, ActionCreators.jumpToPast(jumpToPastIndex))
+      })
+      it('should change present to a given value from past', () => {
+        const pastState = incrementedState.past[jumpToPastIndex]
+        if (pastState !== undefined) {
+          expect(jumpToPastState.present).to.equal(pastState)
+        }
+      })
+      it('should do nothing if past index is out of bounds', () => {
+        let jumpToOutOfBounds = mockUndoableReducer(incrementedState, ActionCreators.jumpToPast(-1))
+        expect(jumpToOutOfBounds).to.deep.equal(incrementedState)
+      })
+      it('should increase the length of future if successful', () => {
+        if (incrementedState.past.length > jumpToPastIndex) {
+          expect(jumpToPastState.future.length).to.be.above(incrementedState.future.length)
+        }
+      })
+      it('should decrease the length of past if successful', () => {
+        if (incrementedState.past.length > jumpToPastIndex) {
+          expect(jumpToPastState.past.length).to.be.below(incrementedState.past.length)
+        }
+      })
+    })
+    describe('JumpToFuture', () => {
+      const jumpToFutureIndex = 2
+      let jumpToFutureState
+      before('perform a jumpToFuture action', () => {
+        jumpToFutureState = mockUndoableReducer(mockInitialState, ActionCreators.jumpToFuture(jumpToFutureIndex))
+      })
+      it('should change present to a given value from future', () => {
+        const futureState = mockInitialState.future[jumpToFutureIndex]
+        if (futureState !== undefined) {
+          expect(jumpToFutureState.present).to.equal(futureState)
+        }
+      })
+      it('should do nothing if future index is out of bounds', () => {
+        let jumpToOutOfBounds = mockUndoableReducer(mockInitialState, ActionCreators.jumpToFuture(-1))
+        expect(jumpToOutOfBounds).to.deep.equal(mockInitialState)
+      })
+      it('should increase the length of past if successful', () => {
+        if (mockInitialState.future.length > jumpToFutureIndex) {
+          expect(jumpToFutureState.past.length).to.be.above(mockInitialState.past.length)
+        }
+      })
+      it('should decrease the length of future if successful', () => {
+        if (mockInitialState.future.length > jumpToFutureIndex) {
+          expect(jumpToFutureState.future.length).to.be.below(mockInitialState.future.length)
+        }
+      })
+    })
+    describe('Clear History', () => {
+      let clearedState
+
+      before('perform a clearHistory action', () => {
+        clearedState = mockUndoableReducer(incrementedState, ActionCreators.clearHistory())
+      })
+      it('should clear future and past', () => {
+        expect(clearedState.past.length).to.equal(0)
+        expect(clearedState.future.length).to.equal(0)
+      })
+      it('should preserve the present value', () => {
+        expect(clearedState.present).to.equal(incrementedState.present)
+      })
     })
   })
-})
+}


### PR DESCRIPTION
Change the signature of `filter` to include the whole history object, and update the README to reflect the changes. This change is backwards compatible with the helper functions `includeActions`, `excludeActions`, and `distinctState`. However **this will probably be breaking if you are use a `filter` function besides one of the helper functions provided by `redux-undo`**