### PR TITLE
Defer initialization of reducer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -219,10 +219,10 @@ export default function undoable (reducer, rawConfig = {}) {
         debug('do not initialize on probe actions')
       } else if (isHistory(state)) {
         history = config.history = state
-        debug('initialHistory properly shaped and initialized', config.history)
+        debug('initialHistory initialized: initialState is a history', config.history)
       } else {
         history = config.history = createHistory(state)
-        debug('initialHistory reshaped and initialized', config.history)
+        debug('initialHistory initialized: initialState is not a history', config.history)
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -207,28 +207,23 @@ export default function undoable (reducer, rawConfig = {}) {
     clearHistoryType: rawConfig.clearHistoryType || ActionTypes.CLEAR_HISTORY
   }
 
-  return (state, action = {}) => {
+  return (state = config.history, action = {}) => {
     debugStart(action, state)
 
-    let history
+    let history = state
     if (!config.history) {
-      debug('create history on init')
+      debug('history is uninitialized')
 
       if (state === undefined) {
-        config.history = createHistory(reducer(state, {}))
+        history = createHistory(reducer(state, {}))
+        debug('do not initialize on probe actions')
       } else if (isHistory(state)) {
-        config.history = state
+        history = config.history = state
+        debug('initialHistory properly shaped and initialized', config.history)
       } else {
-        config.history = createHistory(state)
+        history = config.history = createHistory(state)
+        debug('initialHistory reshaped and initialized', config.history)
       }
-
-      history = config.history
-    } else if (state === undefined) {
-      // If reducer is called with undefined, use our saved history as the state
-      // since that was the result of calling the reducer the initially
-      history = config.history
-    } else {
-      history = state
     }
 
     let res


### PR DESCRIPTION
So reactjs/redux calls this function when initializing a reducer: https://github.com/reactjs/redux/blob/master/src/combineReducers.js#L49. That will dispatch two actions to the store with the value `state === undefined`. Then `@@redux/INIT` is dispatched with the `initialState` argument of `createStore(...)`.

So the series of actions are:
```js
  1. reducer(undefined, '@@redux/INIT')
  2. reducer(undefined, '@@redux/PROBE_UNKNOWN_ACTION_random...')
  3. reducer(initialState, '@@redux/INIT')
```

If we want to support an `initialState` that is not shaped like a `history`, we need to initialize the `undoable` reducer only after it stops receiving all these `state === undefined` actions. With this change, do not initialize `config.history` if the `undoable` is called with an undefined state.