### PR TITLE
feat(build): Adding UMD support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .DS_Store
 lib
 coverage
+dist
+es

--- a/README.md
+++ b/README.md
@@ -266,6 +266,28 @@ Have a read of the [Implementing Undo History recipe](http://redux.js.org/docs/r
 
 If you have a question or just want to discuss something with other redux-undo users/maintainers, [chat with the community on gitter.im/omnidan/redux-undo](https://gitter.im/omnidan/redux-undo)
 
+## Note
+
+If you use Redux Undo in CommonJS environment, **don’t forget to add `.default` to your import**.
+
+```diff
+- var ReduxUndo = require('redux-undo')
++ var ReduxUndo = require('redux-undo').default
+```
+
+If your environment support es modules just go by:
+
+```js
+import ReduxUndo from 'redux-undo';
+```
+
+We are also supporting UMD build:
+
+```js
+var ReduxThunk = window.ReduxThunk.default;
+```
+
+**once again `.default` is required.**
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import ReduxUndo from 'redux-undo';
 We are also supporting UMD build:
 
 ```js
-var ReduxThunk = window.ReduxThunk.default;
+var ReduxUndo = window.ReduxUndo.default;
 ```
 
 **once again `.default` is required.**

--- a/README.md
+++ b/README.md
@@ -17,6 +17,28 @@ or plan on using 0.6, check out [the `0.6` branch](https://github.com/omnidan/re
 
 ---
 
+## Note on 1.0.0-beta7
+
+If you use Redux Undo in CommonJS environment, **don’t forget to add `.default` to your import**.
+
+```diff
+- var ReduxUndo = require('redux-undo')
++ var ReduxUndo = require('redux-undo').default
+```
+
+If your environment support es modules just go by:
+
+```js
+import ReduxUndo from 'redux-undo';
+```
+
+We are also supporting UMD build:
+
+```js
+var ReduxThunk = window.ReduxThunk.default;
+```
+
+**once again `.default` is required.**
 
 ## Installation
 
@@ -265,29 +287,6 @@ Have a read of the [Implementing Undo History recipe](http://redux.js.org/docs/r
 ## Gitter Chat / Support
 
 If you have a question or just want to discuss something with other redux-undo users/maintainers, [chat with the community on gitter.im/omnidan/redux-undo](https://gitter.im/omnidan/redux-undo)
-
-## Note
-
-If you use Redux Undo in CommonJS environment, **don’t forget to add `.default` to your import**.
-
-```diff
-- var ReduxUndo = require('redux-undo')
-+ var ReduxUndo = require('redux-undo').default
-```
-
-If your environment support es modules just go by:
-
-```js
-import ReduxUndo from 'redux-undo';
-```
-
-We are also supporting UMD build:
-
-```js
-var ReduxThunk = window.ReduxThunk.default;
-```
-
-**once again `.default` is required.**
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -4,14 +4,18 @@
   "description": "simple undo/redo functionality for redux state containers",
   "main": "lib/index.js",
   "scripts": {
-    "clean": "./node_modules/.bin/rimraf lib",
-    "compile": "./node_modules/.bin/babel src --out-dir lib",
+    "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min && npm run build:es",
+    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
+    "build:umd": "cross-env BABEL_ENV=commonjs NODE_ENV=development webpack",
+    "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack",
+    "clean": "./node_modules/.bin/rimraf lib dist es",
     "lint": "./node_modules/.bin/eslint src test",
+    "prepublish": "npm run lint && npm run test && npm run clean && npm run build",
     "test": "NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register",
-    "test:watch": "npm run test -- --watch",
     "test:bail": "npm run test:watch -- --bail",
     "test:cov": "./node_modules/.bin/babel-node ./node_modules/.bin/isparta cover ./node_modules/.bin/_mocha",
-    "prepublish": "npm run lint && npm run test && npm run clean && npm run compile"
+    "test:watch": "npm run test -- --watch"
   },
   "repository": {
     "type": "git",
@@ -34,8 +38,10 @@
     "babel-cli": "^6.5.1",
     "babel-core": "^6.5.2",
     "babel-eslint": "^5.0.0",
+    "babel-loader": "^6.2.4",
     "babel-plugin-transform-object-rest-spread": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
+    "cross-env": "^1.0.7",
     "chai": "^3.5.0",
     "eslint": "2.2.0",
     "eslint-config-standard": "^5.1.0",
@@ -44,7 +50,8 @@
     "expect": "^1.14.0",
     "isparta": "^4.0.0",
     "mocha": "^2.4.5",
-    "rimraf": "^2.5.2"
+    "rimraf": "^2.5.2",
+    "webpack": "^1.12.14"
   },
   "dependencies": {
     "redux": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:umd": "cross-env BABEL_ENV=commonjs NODE_ENV=development webpack",
     "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack",
     "clean": "./node_modules/.bin/rimraf lib dist es",
-    "lint": "./node_modules/.bin/eslint src test",
+    "lint": "./node_modules/.bin/eslint webpack.config.babel.js src test",
     "prepublish": "npm run lint && npm run test && npm run clean && npm run build",
     "test": "NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register",
     "test:bail": "npm run test:watch -- --bail",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-undo",
-  "version": "1.0.0-beta6",
+  "version": "1.0.0-beta7",
   "description": "simple undo/redo functionality for redux state containers",
   "main": "lib/index.js",
   "scripts": {

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,46 +1,46 @@
-import webpack from 'webpack';
-import path from 'path';
+import webpack from 'webpack'
+import path from 'path'
 
-const { NODE_ENV } = process.env;
+const { NODE_ENV } = process.env
 
 const plugins = [
   new webpack.optimize.OccurenceOrderPlugin(),
   new webpack.DefinePlugin({
-    'process.env.NODE_ENV': JSON.stringify(NODE_ENV),
-  }),
-];
+    'process.env.NODE_ENV': JSON.stringify(NODE_ENV)
+  })
+]
 
-const filename = `redux-undo${NODE_ENV === 'production' ? '.min' : ''}.js`;
+const filename = `redux-undo${NODE_ENV === 'production' ? '.min' : ''}.js`
 
-NODE_ENV === 'production'  && plugins.push(
+NODE_ENV === 'production' && plugins.push(
   new webpack.optimize.UglifyJsPlugin({
     compressor: {
       pure_getters: true,
       unsafe: true,
       unsafe_comps: true,
       screw_ie8: true,
-      warnings: false,
-    },
+      warnings: false
+    }
   })
-);
+)
 
 export default {
   module: {
     loaders: [
-      { test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ },
-    ],
+      { test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ }
+    ]
   },
 
   entry: [
-    './src/index',
+    './src/index'
   ],
 
   output: {
     path: path.join(__dirname, 'dist'),
     filename,
     library: 'ReduxUndo',
-    libraryTarget: 'umd',
+    libraryTarget: 'umd'
   },
 
-  plugins,
-};
+  plugins
+}

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,0 +1,46 @@
+import webpack from 'webpack';
+import path from 'path';
+
+const { NODE_ENV } = process.env;
+
+const plugins = [
+  new webpack.optimize.OccurenceOrderPlugin(),
+  new webpack.DefinePlugin({
+    'process.env.NODE_ENV': JSON.stringify(NODE_ENV),
+  }),
+];
+
+const filename = `redux-undo${NODE_ENV === 'production' ? '.min' : ''}.js`;
+
+NODE_ENV === 'production'  && plugins.push(
+  new webpack.optimize.UglifyJsPlugin({
+    compressor: {
+      pure_getters: true,
+      unsafe: true,
+      unsafe_comps: true,
+      screw_ie8: true,
+      warnings: false,
+    },
+  })
+);
+
+export default {
+  module: {
+    loaders: [
+      { test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ },
+    ],
+  },
+
+  entry: [
+    './src/index',
+  ],
+
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename,
+    library: 'ReduxUndo',
+    libraryTarget: 'umd',
+  },
+
+  plugins,
+};


### PR DESCRIPTION
As mentioned in #81, UMD build support

adding minimal webpack config for building commonjs/umd/es,
followed [redux-thunk](https://github.com/gaearon/redux-thunk/blob/master/webpack.config.babel.js) config.

*its still missing a version bump + a note about umd support on `README.md`*
