### PR TITLE
Add "cross-env" before setting the NODE_ENV environment variable in t…

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "./node_modules/.bin/rimraf lib dist es",
     "lint": "./node_modules/.bin/eslint webpack.config.babel.js src test",
     "prepublish": "npm run lint && npm run test && npm run clean && npm run build",
-    "test": "NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register",
+    "test": "cross-env NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register",
     "test:bail": "npm run test:watch -- --bail",
     "test:cov": "./node_modules/.bin/babel-node ./node_modules/.bin/isparta cover --root src/ ./node_modules/.bin/_mocha",
     "test:coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",


### PR DESCRIPTION
…he "test" script in package.json

This allows npm to run the "test" script in Windows.