### PR TITLE
add the function to change the filter

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -4,7 +4,8 @@ export const ActionTypes = {
   JUMP_TO_FUTURE: '@@redux-undo/JUMP_TO_FUTURE',
   JUMP_TO_PAST: '@@redux-undo/JUMP_TO_PAST',
   JUMP: '@@redux-undo/JUMP',
-  CLEAR_HISTORY: '@@redux-undo/CLEAR_HISTORY'
+  CLEAR_HISTORY: '@@redux-undo/CLEAR_HISTORY',
+  CHANGE_FILTER: '@@redux-undo/CHANGE_FILTER'
 }
 
 export const ActionCreators = {
@@ -25,5 +26,8 @@ export const ActionCreators = {
   },
   clearHistory () {
     return { type: ActionTypes.CLEAR_HISTORY }
+  },
+  changeFilter (filter) {
+    return { type: ActionTypes.CHANGE_FILTER, filter }
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -505,5 +505,35 @@ function runTests (label, { undoableConfig, initialStoreState, testConfig } = {}
         expect(clearedState.present).to.equal(incrementedState.present)
       })
     })
+
+    describe('Change Filter', () => {
+      let filteredState, notFilteredState, filteredReducer, notFilteredReducer
+
+      before('perform a changeFilter action to not record action', () => {
+        filteredReducer = undoable(countReducer, {})
+      })
+
+      it('should not record unwanted actions', () => {
+        filteredState = filteredReducer(mockInitialState, { type: 'INCREMENT' })
+        filteredState = filteredReducer(filteredState, ActionCreators.changeFilter(excludeAction(decrementActions)))
+        notFilteredReducer = undoable(countReducer, { filter: null })
+        notFilteredState = notFilteredReducer(mockInitialState, { type: 'INCREMENT' })
+
+        filteredState = filteredReducer(filteredState, { type: 'DECREMENT' })
+        filteredState = filteredReducer(filteredState, { type: 'DECREMENT' })
+        expect(filteredState.past).to.deep.equal(notFilteredState.past)
+      })
+
+      it('should record wanted actions', () => {
+        filteredState = filteredReducer(mockInitialState, { type: 'INCREMENT' })
+        filteredState = filteredReducer(filteredState, ActionCreators.changeFilter(excludeAction(decrementActions)))
+        notFilteredReducer = undoable(countReducer, { filter: null })
+        notFilteredState = notFilteredReducer(mockInitialState, { type: 'INCREMENT' })
+
+        filteredState = filteredReducer(filteredState, { type: 'INCREMENT' })
+        notFilteredState = notFilteredReducer(notFilteredState, { type: 'INCREMENT' })
+        expect(filteredState).to.deep.equal(notFilteredState)
+      })
+    })
   })
 }


### PR DESCRIPTION
I want to change the filter config dynamically.
Sometimes I want to undo some actions at the same time.
The use case example is below.

```
const deleteTargetIds = ['id1','id2','id3'];
ActionCreators.changeFilter(() => false);

deleteTargetIds.forEach(id => {
	deleteAction(id);
});

ActionCreators.changeFilter(() => true);
