### PR TITLE
Add definitions for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-beta9",
   "description": "simple undo/redo functionality for redux state containers",
   "main": "lib/index.js",
+  "typings": "typings.d.ts",
   "jspm": {
     "main": "src/index.js",
     "format": "esm"

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,68 @@
+import { Reducer, Action } from 'redux';
+
+module 'redux-undo' {
+  export interface StateWithHistory<State> {
+    past: State[];
+    present: State;
+    future: State[];
+  }
+
+  export type FilterFunction = (action: Action) => boolean;
+  export type combineFilters = (...filters: FilterFunction[]) => FilterFunction;
+
+  interface Options {
+    /* Set a limit for the history */
+    limit?: number;
+
+    /** If you don't want to include every action in the undo/redo history, you can add a filter function to undoable */
+    filter?: FilterFunction;
+
+    /** Define a custom action type for this undo action */
+    undoType?: string;
+    /** Define a custom action type for this redo action */
+    redoType?: string;
+
+    /** Define custom action type for this jump action */
+    jumpType?: string;
+
+    /** Define custom action type for this jumpToPast action */
+    jumpToPastType?: string;
+    /** Define custom action type for this jumpToFuture action */
+    jumpToFutureType?: string;
+
+    /** [beta only] Define custom action type for this clearHistory action */
+    clearHistoryType?: string;
+
+    /** History will be (re)set upon init action type */
+    initTypes?: string[];
+
+    /** Set to `true` to turn on debugging */
+    debug?: boolean; 
+  }
+
+  interface Undoable {
+    <State>(reducer: Reducer<State>, options?: Options): Reducer<StateWithHistory<State>>;
+  }
+
+
+  type includeAction = (actions: string | string[]) => FilterFunction;
+  type excludeAction = typeof includeAction;
+
+  const undoable: Undoable;
+
+  export default undoable;
+
+  /**
+   * If you don't want to include every action in the undo/redo history, you can add a filter function to undoable.
+   * redux-undo provides you with the includeAction and excludeAction helpers for basic filtering.
+   */
+  export const includeAction: includeAction;
+
+  /**
+   * If you don't want to include every action in the undo/redo history, you can add a filter function to undoable.
+   * redux-undo provides you with the includeAction and excludeAction helpers for basic filtering.
+   */
+  export const excludeAction: excludeAction;
+
+  export const combineFilters: combineFilters;
+}

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -8,7 +8,7 @@ module 'redux-undo' {
   }
 
   export type FilterFunction = (action: Action) => boolean;
-  export type combineFilters = (...filters: FilterFunction[]) => FilterFunction;
+  export type CombineFilters = (...filters: FilterFunction[]) => FilterFunction;
 
   interface Options {
     /* Set a limit for the history */
@@ -45,8 +45,8 @@ module 'redux-undo' {
   }
 
 
-  type includeAction = (actions: string | string[]) => FilterFunction;
-  type excludeAction = typeof includeAction;
+  type IncludeAction = (actions: string | string[]) => FilterFunction;
+  type ExcludeAction = typeof IncludeAction;
 
   const undoable: Undoable;
 
@@ -56,13 +56,13 @@ module 'redux-undo' {
    * If you don't want to include every action in the undo/redo history, you can add a filter function to undoable.
    * redux-undo provides you with the includeAction and excludeAction helpers for basic filtering.
    */
-  export const includeAction: includeAction;
+  export const includeAction: IncludeAction;
 
   /**
    * If you don't want to include every action in the undo/redo history, you can add a filter function to undoable.
    * redux-undo provides you with the includeAction and excludeAction helpers for basic filtering.
    */
-  export const excludeAction: excludeAction;
+  export const excludeAction: ExcludeAction;
 
-  export const combineFilters: combineFilters;
+  export const combineFilters: CombineFilters;
 }


### PR DESCRIPTION
This helps IDEs like VS Code and Atom with TypeScript plugins understand the types of different functions and exports and warn about issues with typos/incompatible types... etc
