### PR TITLE
Unfiltered snapshots feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack",
     "clean": "./node_modules/.bin/rimraf lib dist es",
     "lint": "./node_modules/.bin/eslint webpack.config.babel.js src test",
-    "prepublish": "npm run lint && npm run test && npm run clean && npm run build",
+    "prepublish": "npm run lint && npm run clean && npm run build",
     "test": "cross-env NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register",
     "test:bail": "npm run test:watch -- --bail",
     "test:cov": "./node_modules/.bin/babel-node ./node_modules/.bin/isparta cover --root src/ ./node_modules/.bin/_mocha",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack",
     "clean": "./node_modules/.bin/rimraf lib dist es",
     "lint": "./node_modules/.bin/eslint webpack.config.babel.js src test",
-    "prepublish": "npm run lint && npm run clean && npm run build",
+    "prepublish": "npm run lint && npm run test && npm run clean && npm run build",
     "test": "cross-env NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register",
     "test:bail": "npm run test:watch -- --bail",
     "test:cov": "./node_modules/.bin/babel-node ./node_modules/.bin/isparta cover --root src/ ./node_modules/.bin/_mocha",

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -227,8 +227,7 @@ export default function undoable (reducer, rawConfig = {}) {
         }
 
         if (typeof config.filter === 'function' && !config.filter(action, res, history)) {
-          // if filtering an action, first check latestUnfiltered, and update past;
-          // then clear _latestUnfiltered and update present
+          // if filtering an action, merely update the present
           const nextState = {
             ...history,
             present: res

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -167,7 +167,11 @@ export default function undoable (reducer, rawConfig = {}) {
         )
         debug.log('do not initialize on probe actions')
       } else if (isHistory(state)) {
-        history = config.history = state
+        history = config.history = config.ignoreInitialState
+          ? state : {
+            ...state,
+            _latestUnfiltered: state.present
+          }
         debug.log('initialHistory initialized: initialState is a history', config.history)
       } else {
         history = config.history = createHistory(state)

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -120,6 +120,9 @@ function jump (history, n) {
 
 // createHistory
 function createHistory (state, ignoreInitialState) {
+  // ignoreInitialState essentially prevents the user from undoing to the
+  // beginning, in the case that the undoable reducer handles initialization
+  // in a way that can't be redone simply
   return ignoreInitialState ? {
     past: [],
     present: state,
@@ -242,7 +245,7 @@ export default function undoable (reducer, rawConfig = {}) {
           debug.end(nextState)
           return nextState
         } else {
-          // If the action was filtered, insert normally
+          // If the action wasn't filtered, insert normally
           history = insert(history, res, config.limit)
 
           debug.log('inserted new state into history')

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -79,12 +79,15 @@ function jumpToFuture (history, index) {
   if (index === 0) return redo(history)
   if (index < 0 || index >= history.future.length) return history
 
-  const { past, present, future } = history
+  const { past, future, _latestUnfiltered } = history
+
+  const newPresent = future[index]
 
   return {
     future: future.slice(index + 1),
-    present: future[index],
-    past: past.concat([present])
+    present: newPresent,
+    _latestUnfiltered: newPresent,
+    past: past.concat([_latestUnfiltered])
       .concat(future.slice(0, index))
   }
 }
@@ -94,13 +97,16 @@ function jumpToPast (history, index) {
   if (index === history.past.length - 1) return undo(history)
   if (index < 0 || index >= history.past.length) return history
 
-  const { past, present, future } = history
+  const { past, future, _latestUnfiltered } = history
+
+  const newPresent = past[index]
 
   return {
     future: past.slice(index + 1)
-      .concat([present])
+      .concat([_latestUnfiltered])
       .concat(future),
-    present: past[index],
+    present: newPresent,
+    _latestUnfiltered: newPresent,
     past: past.slice(0, index)
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -42,6 +42,7 @@ runTests('Initial History and Filter (Exclude Actions)', {
   initialStoreState: {
     past: [0, 1, 2, 3],
     present: 4,
+    _latestUnfiltered: 4,
     future: [5, 6, 7]
   },
   testConfig: {
@@ -56,6 +57,7 @@ runTests('Initial State and Init types', {
   initialStoreState: {
     past: [123],
     present: 5,
+    _latestUnfiltered: 5,
     future: [-1, -2, -3]
   }
 })
@@ -67,6 +69,7 @@ runTests('Erroneous configuration', {
   initialStoreState: {
     past: [5, {}, 3, null, 1],
     present: Math.pow(2, 32),
+    _latestUnfiltered: Math.pow(2, 32),
     future: []
   }
 })
@@ -132,6 +135,7 @@ function runTests (label, { undoableConfig = {}, initialStoreState, testConfig }
           expect(mockInitialState).to.deep.equal({
             past: [],
             present: initialStoreState,
+            _latestUnfiltered: initialStoreState,
             future: []
           })
         }
@@ -180,21 +184,25 @@ function runTests (label, { undoableConfig = {}, initialStoreState, testConfig }
       it('should not record unwanted actions', () => {
         if (testConfig && testConfig.excludedActions) {
           const excludedAction = { type: testConfig.excludedActions[0] }
+          const includedAction = { type: 'INCREMENT' }
           const notFilteredReducer = undoable(countReducer, { ...undoableConfig, filter: null })
-          let expected = {
-            ...notFilteredReducer(mockInitialState, excludedAction),
-            // because action is filtered, this state should be indicated as filtered
-            wasFiltered: true
-          }
-          // should store state (to store the previous present caused by a not filtered action into the past)
-          let actual = mockUndoableReducer(mockInitialState, excludedAction)
+          let expected = notFilteredReducer(mockInitialState, includedAction)
+          // should store state with included actions
+          let actual = mockUndoableReducer(mockInitialState, includedAction)
           expect(actual).to.deep.equal(expected)
           // but not this one... (keeping the presents caused by filtered actions out of the past)
+          // (Below, move forward by two filtered actions)
           expected = {
             ...expected,
-            present: notFilteredReducer(expected, excludedAction).present
+            present: notFilteredReducer(
+              notFilteredReducer(expected, excludedAction),
+              excludedAction
+            ).present
           }
-          actual = mockUndoableReducer(actual, excludedAction)
+          actual = mockUndoableReducer(
+            mockUndoableReducer(actual, excludedAction),
+            excludedAction
+          )
           expect(actual).to.deep.equal(expected)
         }
 
@@ -205,14 +213,9 @@ function runTests (label, { undoableConfig = {}, initialStoreState, testConfig }
           const commonInitialState = mockUndoableReducer(mockInitialState, includedAction)
 
           const notFilteredReducer = undoable(countReducer, { ...undoableConfig, filter: null })
-          let expected = notFilteredReducer(commonInitialState, excludedAction)
-          expected = {
-            ...expected,
-            // because increment action is filtered, this state should be indicated as filtered
-            wasFiltered: true
-          }
-          // and this one, (to store the previous present caused by a not filtered action into the past)
-          let actual = mockUndoableReducer(commonInitialState, excludedAction)
+          let expected = notFilteredReducer(commonInitialState, includedAction)
+          // and this one - should work with included actions just fine
+          let actual = mockUndoableReducer(commonInitialState, includedAction)
           expect(actual).to.deep.equal(expected)
           // but not this one... (keeping the presents caused by filtered actions out of the past)
           expected = {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -42,7 +42,6 @@ runTests('Initial History and Filter (Exclude Actions)', {
   initialStoreState: {
     past: [0, 1, 2, 3],
     present: 4,
-    _latestUnfiltered: 4,
     future: [5, 6, 7]
   },
   testConfig: {
@@ -57,7 +56,6 @@ runTests('Initial State and Init types', {
   initialStoreState: {
     past: [123],
     present: 5,
-    _latestUnfiltered: 5,
     future: [-1, -2, -3]
   }
 })
@@ -69,7 +67,6 @@ runTests('Erroneous configuration', {
   initialStoreState: {
     past: [5, {}, 3, null, 1],
     present: Math.pow(2, 32),
-    _latestUnfiltered: Math.pow(2, 32),
     future: []
   }
 })
@@ -126,7 +123,17 @@ function runTests (label, { undoableConfig = {}, initialStoreState, testConfig }
 
       it('should be initialized with the the store\'s initial `history` if provided', () => {
         if (initialStoreState !== undefined && isHistory(initialStoreState)) {
-          expect(mockInitialState).to.deep.equal(initialStoreState)
+          const expected = {
+            past: mockInitialState.past,
+            present: mockInitialState.present,
+            future: mockInitialState.future
+          }
+          const actual = {
+            past: initialStoreState.past,
+            present: initialStoreState.present,
+            future: initialStoreState.future
+          }
+          expect(expected).to.deep.equal(actual)
         }
       })
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -384,13 +384,13 @@ function runTests (label, { undoableConfig = {}, initialStoreState, testConfig }
         if (testConfig && testConfig.excludedActions) {
           const excludedAction = { type: testConfig.excludedActions[0] }
           // handle excluded action on a not filtered initial state
-          let state = mockUndoableReducer(mockInitialState, excludedAction)
+          const excludedState = mockUndoableReducer(mockInitialState, excludedAction)
           // undo
-          let postRedoState = mockUndoableReducer(state, ActionCreators.undo())
+          const postUndoState = mockUndoableReducer(excludedState, ActionCreators.undo())
           // redo
-          state = mockUndoableReducer(postRedoState, ActionCreators.redo())
+          const postRedoState = mockUndoableReducer(postUndoState, ActionCreators.redo())
           // redo should be ignored, because future state wasn't stored
-          expect(state).to.deep.equal(postRedoState)
+          expect(mockInitialState).to.deep.equal(postRedoState)
         }
       })
     })


### PR DESCRIPTION
This pull request removes the wasFiltered flag (the source of a number of bugs), and replaces it with a _latestUnfiltered state object. The purpose of this object is to track the most recent unfiltered state, in order save the correct state object to the past at the correct time (not too early).

The basic premise:
-When updating new (unfiltered) present state, push _latestUnfiltered to the past stack (if it exists), and update both the present and _latestUnfiltered state objects with the latest state
-When inserting filtered present state, merely update the present state
-When undoing, push the _latestUnfiltered state to the future stack, and update both the present and _latestUnfiltered state objects to the most recent past
-When redoing, push the _latestUnfiltered state to the past stack, and update both the present and _latestUnfiltered state objects to the nearest future

I've also updated the unit tests to account for this; let me know if you have any questions/concerns

---------------------------------------------------------------------
Example functionality changes
---------------------------------------------------------------------
Actions:
Action A = unfiltered action
Action F = filtered action (typically fired by a thunk for redux form's internal state)

Before this pull request:
1: Action A happens
2: Action F happens <--- line 1's state is added to past (Undo will have to be clicked 1 too many times!)
3: Action F happens
4: Action A happens
5: Action F happens <--- line 4's state is added to past
6. Action A happens

After this pull request:
1: Action A happens <--- snapshot of "most recent unfiltered state" is taken
2: Action F happens
3: Action F happens
4: Action A happens <--- line 1's state is added to past; snapshot of "most recent unfiltered state" is taken
5: Action F happens
6. Action A happens <--- line 4's state is added to past; snapshot of "most recent unfiltered state" is taken