### PR TITLE
assign config.history to the initialized history when passed initial …

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -169,7 +169,7 @@ export default function undoable (reducer, rawConfig = {}) {
       debug.log('history is uninitialized')
 
       if (state === undefined) {
-        history = createHistory(reducer(
+        history = config.history = createHistory(reducer(
           state, { type: '@@redux-undo/CREATE_HISTORY' }),
           config.ignoreInitialState
         )


### PR DESCRIPTION
…state is undefined

This fixes inconsistent undo behavior when initial state is undefined, as mentioned in https://github.com/omnidan/redux-undo/issues/106