### PR TITLE
Diff Implementation and integration with undo/redo

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -1,0 +1,509 @@
+import * as debug from './debug'
+
+export function shallowClone(val) {
+  if (typeof val === 'object') {
+    if (val === null) {
+      return val
+    }
+    else if (Array.isArray(val)) {
+      return [].concat(val)
+    }
+    else {
+      return Object.assign(Object.create(Object.getPrototypeOf(val)), val)
+    }
+  }
+  else {
+    return val
+  }
+}
+
+export function deepClone(val) {
+  if (typeof val === 'object') {
+    if (val === null) {
+      return null
+    }
+    else if (Array.isArray(val)) {
+      return val.map((element) => deepClone(element))
+    }
+    else {
+      let keys = Object.keys(val)
+      let clone = Object.create(Object.getPrototypeOf(val))
+      for (let key of keys) {
+        clone[key] = deepClone(val[key])
+      }
+      return clone
+    }
+  }
+  else {
+    return val
+  }
+}
+
+function deepEqualsObject(lhs, rhs) {
+  let unionKeys = Object.keys(Object.assign({}, lhs, rhs))
+
+  for (let key of unionKeys) {
+    if (!lhs.hasOwnProperty(key)) {
+      return false
+    }
+    else if (!rhs.hasOwnProperty(key)) {
+      return false
+    }
+    else {
+      if (!deepEquals(lhs[key], rhs[key])) {
+        return false
+      }
+    }
+    return true
+  }
+}
+
+function deepEqualsArray(lhs, rhs) {
+  if (lhs.length !== rhs.length)
+    return false
+  for (let i = 0; i < lhs.length; i++) {
+    if (!deepEquals(lhs[i], rhs[i]))
+      return false
+  }
+  return true
+}
+
+export function deepEquals(lhs, rhs) {
+  if (Object.is(lhs, rhs)) {
+    return true
+  }
+  else if (typeof lhs !== typeof rhs) {
+    return false
+  }
+  else if (typeof lhs === 'object') {
+    if (lhs === null || rhs === null) {
+      return false
+    }
+    else if (Object.getPrototypeOf(lhs) !== Object.getPrototypeOf(rhs)) {
+      return false
+    }
+    else if (Array.isArray(lhs)) {
+      return deepEqualsArray(lhs, rhs)
+    }
+    else {
+      return deepEqualsObject(lhs, rhs)
+    }
+  }
+  else {
+    return false
+  }
+}
+
+function diffGeneric(lhs, rhs, path) {
+  return [{
+    kind: 'E',
+    path: path,
+    lhs: lhs,
+    rhs: rhs
+  }]
+}
+
+function diffObject(lhs, rhs, path) {
+  let diffs = []
+  let unionKeys = Object.keys(Object.assign({}, lhs, rhs))
+
+  for (let key of unionKeys) {
+    if (!lhs.hasOwnProperty(key)) {
+      diffs.push({
+        kind: 'N',
+        path: path.concat(key),
+        rhs: rhs[key]
+      })
+    }
+    else if (!rhs.hasOwnProperty(key)) {
+      diffs.push({
+        kind: 'D',
+        path: path.concat(key),
+        lhs: lhs[key]
+      })
+    }
+    else {
+      diffs.push(...diff(lhs[key], rhs[key], path.concat(key)))
+    }
+  }
+  return diffs
+}
+
+// Implementing LCS (https://en.wikipedia.org/wiki/Longest_common_subsequence_problem)
+// for array diff-ing is hugely inefficient and largely useless for the redux
+// use case. Most redux reducers only insert or delete one element from an
+// array. Therefore, this algorithm checks if the values are Object.is()
+// equal; if not, it looks for whether the element in question was added or
+// removed from the array. If all this fails, it will do a dumb position based diff.
+function diffArray(lhs, rhs, path) {
+  let diffs = []
+  let lhsIndex = 0
+  let rhsIndex = 0
+  while (lhsIndex < lhs.length || rhsIndex < rhs.length) {
+    let left = lhs[lhsIndex]
+    let right = rhs[rhsIndex]
+    if (lhsIndex >= lhs.length) {
+      diffs.push({
+        kind: 'N',
+        path: path.concat(rhsIndex),
+        rhs: right
+      })
+      rhsIndex++;
+    }
+    else if (rhsIndex >= rhs.length) {
+      diffs.push({
+        kind: 'D',
+        path: path.concat(lhsIndex),
+        lhs: left
+      })
+      lhsIndex++
+    }
+    else if (Object.is(left, right)) {
+      lhsIndex++
+      rhsIndex++
+    }
+    else if (lhsIndex+1 < lhs.length && Object.is(right, lhs[lhsIndex+1])) {
+      diffs.push({
+        kind: 'D',
+        path: path.concat(lhsIndex),
+        lhs: left
+      })
+      lhsIndex++
+    }
+    else if (rhsIndex+1 < rhs.length && Object.is(left, rhs[rhsIndex+1])) {
+      diffs.push({
+        kind: 'N',
+        path: path.concat(rhsIndex),
+        rhs: right
+      })
+      rhsIndex++;
+    }
+    else {
+      diffs.push(...diff(left, right, path.concat(lhsIndex)))
+      lhsIndex++
+      rhsIndex++
+    }
+  }
+  return diffs
+}
+
+export function diff(lhs, rhs, path = []) {
+  if (Object.is(lhs, rhs)) {
+    return []
+  }
+  else if (typeof lhs !== typeof rhs) {
+    return diffGeneric(lhs, rhs, path)
+  }
+  else if (typeof lhs === 'object') {
+    if (lhs === null || rhs === null) {
+      return diffGeneric(lhs, rhs, path)
+    }
+    else if (Object.getPrototypeOf(lhs) !== Object.getPrototypeOf(rhs)) {
+      return diffGeneric(lhs, rhs, path)
+    }
+    else if (Array.isArray(lhs)) {
+      return diffArray(lhs, rhs, path)
+    }
+    else {
+      return diffObject(lhs, rhs, path)
+    }
+  }
+  else {
+    return diffGeneric(lhs, rhs, path)
+  }
+}
+
+function createPath(arrPath, len) {
+  if (len === undefined)
+    len = arrPath.length
+  return arrPath.slice(0, len).join('.');
+}
+
+function parsePath(strPath) {
+  return strPath.split('.').map((x) => {
+    let number;
+    if ((number = parseInt(x)))
+      return number;
+    else
+      return x;
+  })
+}
+
+export function findIndexOf(arr, val, inclusive = true) {
+  let low = 0
+  let hig = arr.length
+  let index
+  while (low <= hig) {
+    index = Math.floor((hig + low) / 2)
+    let comp = arr[index]
+    if (val < comp) {
+      hig = index - 1
+    }
+    else if (comp < val) {
+      low = index + 1
+    }
+    else {
+      break;
+    }
+  }
+  if (inclusive) {
+    while (arr[index] < val || arr[index + 1] === val) {
+      index++
+    }
+  }
+  else {
+    // get the index directly following target value
+    while (arr[index] <= val) {
+      index++
+    }
+  }
+  return index
+}
+
+function insertCacheChild(cache, childKey, modified) {
+  if (modified === undefined) modified = false
+  if (!cache.children) {
+    cache.children = { [childKey]: { modified: modified } }
+  }
+  else if (!cache.children[childKey]) {
+    cache.children[childKey] = { modified: modified }
+  }
+  return cache.children[childKey]
+}
+
+function applyArrayDiff(base, diff, cache, curPathIndex, revert = false) {
+  let {kind, path} = diff
+
+  let origIndex = path[curPathIndex]
+
+  if (!Array.isArray(base)) {
+    debug.log("ERROR: Array operation on non-array")
+    return base
+  }
+
+  if (!cache.N)
+    cache.N = []
+  if (!cache.D)
+    cache.D = []
+
+  if (!cache.modified) {
+    cache.modified = true
+    base = shallowClone(base)
+  }
+
+  let numInserts = findIndexOf(cache.N, origIndex, false)
+  let numDeletes = findIndexOf(cache.D, origIndex, false)
+
+  let targetIndex = origIndex
+  if (!revert) {
+    targetIndex = origIndex + numInserts - numDeletes
+  }
+
+  if (targetIndex > base.length - (kind === 'N' ? 0 : 1)) {
+    debug.log("ERROR: array index", origIndex, "is out of bounds")
+    return base
+  }
+
+  if (kind === 'N') {
+    cache.N.splice(numInserts, 0, origIndex)
+    base.splice(targetIndex, 0, diff.rhs)
+  }
+  else if (kind === 'D') {
+    if (!deepEquals(diff.lhs, base[targetIndex])) {
+      debug.log("ERROR: Expected lhs", base[targetIndex], "to equal", diff.lhs)
+    }
+    cache.D.splice(numDeletes, 0, origIndex)
+    base.splice(targetIndex, 1)
+  }
+  return base
+}
+
+function applyDiff(base, diff, cache, curPathIndex, revert = false) {
+  let {kind, path} = diff
+
+  if (curPathIndex === path.length) {
+    if (kind === 'E') {
+      if (!deepEquals(diff.lhs, base)) {
+        debug.log("ERROR: Expected lhs", base, "to equal", diff.lhs)
+      }
+      let cacheKeys = Object.keys(cache)
+      for (let key of cacheKeys) {
+        delete cache[key]
+      }
+      cache.modified = true
+      return diff.rhs
+    }
+    else if (kind === 'N' || kind === 'D') {
+      debug.log("ERROR: Add or Delete diff cannot exist on root path")
+      return base
+    }
+  }
+  else if (curPathIndex === path.length - 1 &&
+           (kind === 'N' || kind === 'D')) {
+    let index = path[curPathIndex]
+    if (typeof index === 'number') {
+      return applyArrayDiff(base, diff, cache, curPathIndex, revert)
+    }
+    else {
+      if (typeof base !== 'object' || base === null) {
+        debug.log("ERROR: expected type", base, "to be non-null object")
+        return base
+      }
+      if (kind === 'N') {
+        if (Object.prototype.hasOwnProperty.call(base, index)) {
+          debug.log("ERROR: base", base, "already has property", index)
+        }
+
+        insertCacheChild(cache, index, true)
+        if (cache.modified) {
+          base[index] = diff.rhs
+          return base
+        }
+        else {
+          cache.modified = true
+          let clone = shallowClone(base)
+          clone[index] = diff.rhs
+          return clone
+        }
+      }
+      else if (kind === 'D') {
+        if (!Object.prototype.hasOwnProperty.call(base, index)) {
+          debug.log("ERROR: base", base, "is missing property", index)
+          return base
+        }
+        if (!deepEquals(diff.lhs, base[index])) {
+          debug.log("ERROR: Expected lhs", base[index], "to equal", diff.lhs)
+        }
+
+        if (cache.children && cache.children[index]) {
+          delete cache.children[index]
+        }
+        if (cache.modified) {
+          delete base[index]
+          return base
+        }
+        else {
+          cache.modified = true
+          let clone = shallowClone(base)
+          delete clone[index]
+          return clone
+        }
+      }
+    }
+  }
+  else {
+    let index = path[curPathIndex]
+    let targetIndex = index
+
+    if (typeof index === 'number') {
+      if (!cache.N) {
+        cache.N = []
+      }
+      if (!cache.D) {
+        cache.D = []
+      }
+      // fixup index
+      let numInserts = findIndexOf(cache.N, index, false)
+      let numDeletes = findIndexOf(cache.D, index, false)
+
+      if (!revert) {
+        targetIndex = index + numInserts - numDeletes
+      }
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(base, targetIndex)) {
+      debug.log("ERROR: base", base, "is missing property", index)
+      return base
+    }
+
+    insertCacheChild(cache, index)
+    if (cache.modified) {
+      base[targetIndex] = applyDiff(base[targetIndex], diff, cache.children[index], curPathIndex + 1, revert)
+      return base
+    }
+    else {
+      cache.modified = true
+      let clone = shallowClone(base)
+      clone[targetIndex] = applyDiff(base[targetIndex], diff, cache.children[index], curPathIndex + 1, revert)
+      return clone
+    }
+  }
+}
+
+export function invertDiffs(diffs) {
+  return diffs.map((d) => {
+    switch (d.kind) {
+      case 'N':
+        return {
+          kind: 'D',
+          path: d.path,
+          lhs: d.rhs
+        }
+      case 'D':
+        return {
+          kind: 'N',
+          path: d.path,
+          rhs: d.lhs
+        }
+      case 'E':
+        return {
+          kind: 'E',
+          path: d.path,
+          lhs: d.rhs,
+          rhs: d.lhs
+        }
+      default:
+        debug.log("ERROR: Undefined diff type", d)
+        return undefined
+    }
+  })
+}
+
+function sortDiffs(diffs) {
+  for (let i = 0; i < diffs.length; i++) {
+    diffs[i].keyIndex = i
+  }
+  diffs.sort((a, b) => {
+    let len = Math.max(a.path.length, b.path.length)
+    for (let i = 0; i < len; i++) {
+      if (i >= a.path.length) {
+        return -1
+      }
+      else if (i >= b.path.length) {
+        return 1
+      }
+      else {
+        let pathA = a.path[i]
+        let pathB = b.path[i]
+        if (typeof pathA !== typeof pathB) {
+          return a.keyIndex - b.keyIndex
+        }
+        else if (pathA !== pathB) {
+          if (typeof pathA === 'number') {
+            return pathA - pathB
+          }
+          else {
+            return pathA.localeCompare(pathB)
+          }
+        }
+      }
+    }
+    return a.keyIndex - b.keyIndex
+  })
+}
+
+export function apply(base, diffs) {
+  let cache = {}
+  for (let d of diffs) {
+    base = applyDiff(base, d, cache, 0, false)
+  }
+  return base
+}
+
+export function revert(base, diffs) {
+  let cache = {}
+  for (let d of invertDiffs(diffs)) {
+    base = applyDiff(base, d, cache, 0, true)
+  }
+  return base
+}

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -158,7 +158,8 @@ export default function undoable (reducer, rawConfig = {}) {
       ? rawConfig.clearHistoryType
       : [rawConfig.clearHistoryType || ActionTypes.CLEAR_HISTORY],
     neverSkipReducer: rawConfig.neverSkipReducer || false,
-    ignoreInitialState: rawConfig.ignoreInitialState || false
+    ignoreInitialState: rawConfig.ignoreInitialState || false,
+    diff: rawConfig.diff || false,
   }
 
   return (state = config.history, action = {}) => {

--- a/test/diff.spec.js
+++ b/test/diff.spec.js
@@ -1,0 +1,602 @@
+import { expect } from 'chai'
+import { diff, deepClone, apply, revert, findIndexOf } from '../src/diff.js'
+import * as debug from "../src/debug.js"
+
+debug.set(true)
+runTestDiff()
+
+function runTestDiff() {
+  describe('Diff', () => {
+
+    it('null case', () => {
+      expect(diff(null, null)).to.eql([])
+    })
+    it('null to undefined', () => {
+      expect(diff(null, undefined)).to.eql([{
+        kind: 'E',
+        path: [],
+        lhs: null,
+        rhs: undefined
+      }])
+    })
+
+    it('string case', () => {
+      expect(diff('Hello' + ' World', 'Hello World')).to.eql([])
+    })
+
+    it('string to undefined', () => {
+      expect(diff('Hello World', undefined)).to.eql([{
+        kind: 'E',
+        path: [],
+        lhs: 'Hello World',
+        rhs: undefined
+      }])
+    })
+
+    it('object to null', () => {
+      expect(diff({}, null)).to.eql([{
+        kind: 'E',
+        path: [],
+        lhs: {},
+        rhs: null
+      }])
+    })
+
+    it('object to array', () => {
+      expect(diff({}, [])).to.eql([{
+        kind: 'E',
+        path: [],
+        lhs: {},
+        rhs: []
+      }])
+    })
+
+    it('object equals object', () => {
+      expect(diff({}, {})).to.eql([])
+    })
+
+    it('object key remove', () => {
+      expect(diff({test: 'test'}, {})).to.eql([{
+        kind: 'D',
+        path: ['test'],
+        lhs: 'test'
+      }])
+    })
+
+    it('object key add', () => {
+      expect(diff({}, {test: 'test'})).to.eql([{
+        kind: 'N',
+        path: ['test'],
+        rhs: 'test'
+      }])
+    })
+
+    it('object key remove undefined', () => {
+      expect(diff({test: undefined}, {})).to.eql([{
+        kind: 'D',
+        path: ['test'],
+        lhs: undefined
+      }])
+    })
+
+    it('object key add undefined', () => {
+      expect(diff({}, {test: undefined})).to.eql([{
+        kind: 'N',
+        path: ['test'],
+        rhs: undefined
+      }])
+    })
+
+    it('object key remove null', () => {
+      expect(diff({test: null}, {})).to.eql([{
+        kind: 'D',
+        path: ['test'],
+        lhs: null
+      }])
+    })
+
+    it('object key add null', () => {
+      expect(diff({}, {test: null})).to.eql([{
+        kind: 'N',
+        path: ['test'],
+        rhs: null
+      }])
+    })
+
+    it('object key edit', () => {
+      expect(diff({test: null}, {test: undefined})).to.eql([{
+        kind: 'E',
+        path: ['test'],
+        lhs: null,
+        rhs: undefined
+      }])
+    })
+
+    it('object key edit same type', () => {
+      expect(diff({test: 3}, {test: 4})).to.eql([{
+        kind: 'E',
+        path: ['test'],
+        lhs: 3,
+        rhs: 4
+      }])
+    })
+
+    it('object key edit object null', () => {
+      expect(diff({test: null}, {test: {}})).to.eql([{
+        kind: 'E',
+        path: ['test'],
+        lhs: null,
+        rhs: {}
+      }])
+    })
+
+    it('object key add nested', () => {
+      expect(diff({test: {}}, {test: {test: null}})).to.eql([{
+        kind: 'N',
+        path: ['test', 'test'],
+        rhs: null
+      }])
+    })
+
+    it('object key delete nested', () => {
+      expect(diff({test: {test: null}}, {test: {}})).to.eql([{
+        kind: 'D',
+        path: ['test', 'test'],
+        lhs: null
+      }])
+    })
+
+    it('object array add', () => {
+      expect(diff([], [1, 2])).to.eql([{
+        kind: 'N',
+        path: [0],
+        rhs: 1
+      },
+      {
+        kind: 'N',
+        path: [1],
+        rhs: 2
+      }])
+    })
+
+    it('object array remove', () => {
+      expect(diff([1, 2], [])).to.eql([{
+        kind: 'D',
+        path: [0],
+        lhs: 1
+      },
+      {
+        kind: 'D',
+        path: [1],
+        lhs: 2
+      }])
+    })
+
+    it('object array add remove', () => {
+      expect(diff([1, 2, 4, 5, 6], [2, 3, 4, 6, 7])).to.eql([{
+        kind: 'D',
+        path: [0],
+        lhs: 1
+      },
+      {
+        kind: 'N',
+        path: [1],
+        rhs: 3
+      },
+      {
+        kind: 'D',
+        path: [3],
+        lhs: 5
+      },
+      {
+        kind: 'N',
+        path: [4],
+        rhs: 7
+      }])
+    })
+
+    it('object array edit', () => {
+      expect(diff([0, 1], [2, 3])).to.eql([{
+        kind: 'E',
+        path: [0],
+        lhs: 0,
+        rhs: 2
+      },
+      {
+        kind: 'E',
+        path: [1],
+        lhs: 1,
+        rhs: 3
+      }])
+    })
+
+    it ('object discriminated by inheritance', () => {
+      class Base {
+        constructor() {
+          this.c = 4;
+        }
+      }
+
+      class Child extends Base {
+        constructor() {
+          super();
+          this.d = 4;
+        }
+      }
+
+      class AnotherBase {
+        constructor() {
+          this.c = 4;
+        }
+      }
+
+      class AnotherChild extends AnotherBase {
+        constructor() {
+          super();
+          this.d = 4;
+        }
+      }
+
+      let result = diff(new Child(), new AnotherChild())
+
+      expect(result).to.eql([{
+        kind: 'E',
+        path: [],
+        lhs: {
+          c: 4,
+          d: 4
+        },
+        rhs: {
+          c: 4,
+          d: 4
+        }
+      }])
+
+      expect(Object.getPrototypeOf(result[0].lhs)).to.equal(Child.prototype)
+      expect(Object.getPrototypeOf(result[0].rhs)).to.equal(AnotherChild.prototype)
+    })
+
+  })
+
+  describe('Deep clone', () => {
+
+    it ('nested object', () => {
+      let x = {
+        a: {
+          b : {
+            c: undefined
+          }
+        }
+      }
+
+      let y = deepClone(x)
+
+      expect(x).to.eql(y)
+      expect(x !== y)
+      expect(x.a !== y.a)
+      expect(x.a.b !== y.a.b)
+      expect(x.a.b.c !== y.a.b.c)
+    })
+
+    it ('nested array', () => {
+      let x = [0, 1, [2, 3, 4], 5]
+      let y = deepClone(x)
+
+      expect(x).to.eql(y)
+      expect(x !== y)
+      expect(x[2] !== y[2])
+    })
+  })
+
+  describe('Apply diff', () => {
+
+    it('replacement', () => {
+      let x = null
+      let diff = [{
+        kind: 'E',
+        path: [],
+        lhs: null,
+        rhs: 1
+      }]
+
+      let y = apply(x, diff)
+      expect(y).to.equal(1)
+    })
+
+    it('nested object', () => {
+      let x = {
+        a: {
+          b: {}
+        }
+      }
+
+      let diff = [{
+        kind: 'N',
+        path: ['a', 'b', 'c'],
+        rhs: {}
+      },
+      {
+        kind: 'N',
+        path: ['a', 'd'],
+        rhs: {
+          e: 2,
+          f: null
+        }
+      },
+      {
+        kind: 'D',
+        path: ['a', 'd', 'e'],
+        lhs: 2
+      },
+      {
+        kind: 'E',
+        path: ['a', 'd', 'f'],
+        lhs: null,
+        rhs: 3
+      }]
+
+      let y = apply(x, diff)
+      expect(y).to.eql({
+        a: {
+          b: {
+            c: {}
+          },
+          d: {
+            f: 3
+          }
+        }
+      })
+    })
+  })
+
+  describe('Array patch', () => {
+
+    it('array inserts', () => {
+      let x = []
+      let diff = [{
+        kind: 'N',
+        path: [0],
+        rhs: 1
+      }]
+
+      let y = apply(x, diff)
+      expect(y).to.eql([1])
+    })
+
+    it('array delete', () => {
+      let x = [1, 2, 3]
+      let diff = [{
+        kind: 'D',
+        path: [1],
+        lhs: 2
+      }]
+
+      let y = apply(x, diff)
+      expect(y).to.eql([1, 3])
+    })
+
+    it('array multiple insert', () => {
+      let x = []
+      let diff = [{
+        kind: 'N',
+        path: [0],
+        rhs: 1
+      },
+      {
+        kind: 'N',
+        path: [0],
+        rhs: 2
+      }]
+      let y = apply(x, diff)
+      expect(y).to.eql([1, 2])
+    })
+
+    it('mixed insert and delete', () => {
+      let x = [1, 3, 3, 5]
+      let diff = [{
+        kind: 'N',
+        path: [1],
+        rhs: 2
+      },
+      {
+        kind: 'D',
+        path: [2],
+        lhs: 3
+      },
+      {
+        kind: 'N',
+        path: [3],
+        rhs: 4
+      }]
+      let y = apply(x, diff)
+      expect(y).to.eql([1, 2, 3, 4, 5])
+    })
+
+    it('reverse insert and delete', () => {
+      let x = [1, 2, 3, 4, 5]
+      let diff = [{
+        kind: 'D',
+        path: [1],
+        lhs: 2
+      },
+      {
+        kind: 'N',
+        path: [2],
+        rhs: 3
+      },
+      {
+        kind: 'D',
+        path: [3],
+        lhs: 4
+      }]
+      let y = apply(x, diff)
+      expect(y).to.eql([1, 3, 3, 5])
+    })
+
+    it('edit works on fixed index', () => {
+      let x = [1, 3, 3, 5]
+      let diff = [{
+        kind: 'N',
+        path: [1],
+        rhs: 2
+      },
+      {
+        kind: 'D',
+        path: [2],
+        lhs: 3
+      },
+      {
+        kind: 'N',
+        path: [3],
+        rhs: 4
+      },
+      {
+        kind: 'N',
+        path: [1],
+        rhs: 'a'
+      },
+      {
+        kind: 'E',
+        path: [1],
+        lhs: 3,
+        rhs: "hi"
+      }]
+      let y = apply(x, diff)
+      expect(y).to.eql([1, 2, 'a', 'hi', 4, 5])
+    })
+  })
+
+  describe('binary search', () => {
+    it('test', () => {
+      let x = [1, 2, 3, 4, 4, 5]
+      let i = findIndexOf(x, 3)
+      expect(i).to.equal(2)
+    })
+
+    it('test2', () => {
+      let x = [1, 2, 4, 4, 4, 5]
+      let i = findIndexOf(x, 4)
+      expect(i).to.equal(4)
+    })
+
+    it('test3', () => {
+      let x = [1, 2, 3, 5]
+      let i = findIndexOf(x, 4)
+      expect(i).to.equal(3)
+    })
+
+    it('non-inclusive', () => {
+      let x = [1, 2, 3, 3, 5]
+      let i = findIndexOf(x, 3, false)
+      expect(i).to.equal(4)
+    })
+  })
+
+  describe('revert', () => {
+    let x = [1, 2, 3, 4, 5]
+    let diff = [{
+      kind: 'N',
+      path: [1],
+      rhs: 2
+    },
+    {
+      kind: 'D',
+      path: [2],
+      lhs: 3
+    },
+    {
+      kind: 'N',
+      path: [3],
+      rhs: 4
+    }]
+    let y = revert(x, diff)
+    expect(y).to.eql([1, 3, 3, 5])
+  })
+
+  describe('inverse', () => {
+    let x = [
+      'x',
+      'a',
+      {
+        b: [
+        0,
+        1,
+        "hello",
+        "!"
+        ]
+      },
+      'c'
+    ]
+    let diff = [
+    {
+      kind: 'D',
+      path: [0],
+      lhs: 'x'
+    },
+    {
+      kind: 'N',
+      path: [1],
+      rhs: 'd'
+    },
+    {
+      kind: 'N',
+      path: [1],
+      rhs: 'c'
+    },
+    {
+      kind: 'D',
+      path: [1],
+      lhs: 'a'
+    },
+    {
+      kind: 'N',
+      path: [2, 'b', 3],
+      rhs: 'world'
+    }]
+
+    let y = apply(x, diff)
+    let xprime = revert(y, diff)
+    expect(xprime).to.eql(x)
+  })
+
+  describe('system', () => {
+    it('works', () => {
+      let a = {
+        a: 'hello',
+        b: 'world',
+        c: [
+          'c',
+          ['porcupine', 3, undefined]
+        ],
+        d: undefined,
+        e: {
+          test: {
+            fly: null
+          }
+        }
+      }
+
+      let b = {
+        a: 'world',
+        b: 'hello',
+        c: [
+          'c',
+          [null, 'porcupine', 5, undefined],
+          'd'
+        ],
+        d: {
+          hello: 'world'
+        },
+        e: {
+          hah: {
+            whatabout: null
+          }
+        }
+      }
+
+      let d = diff(a, b)
+      expect(apply(a, d)).to.eql(b)
+      expect(revert(b, d)).to.eql(a)
+    })
+  })
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -77,10 +77,54 @@ runTests('Erroneous configuration', {
 })
 runTests('Diff', {
   undoableConfig: {
-    enableDiff: true
+    enableDiff: true,
+    limit: 200
   }
 })
-
+runTests('Diff – Default config', {
+  undoableConfig: {
+    enableDiff: true,
+  }
+})
+runTests('Diff – Never skip reducer', {
+  undoableConfig: {
+    enableDiff: true,
+    neverSkipReducer: true
+  }
+})
+runTests('Diff – No Init types', {
+  undoableConfig: {
+    enableDiff: true,
+    initTypes: []
+  }
+})
+runTests('Diff – Initial State equals 100', {
+  undoableConfig: {
+    enableDiff: true,
+    limit: 200
+  },
+  initialStoreState: 100
+})
+runTests('Diff – Initial State that looks like a history', {
+  undoableConfig: {},
+  enableDiff: true,
+  initialStoreState: {'present': 0}
+})
+runTests('Diff – Filter (Include Actions)', {
+  undoableConfig: {
+    enableDiff: true,
+    filter: includeAction(decrementActions)
+  },
+  testConfig: {
+    includeActions: decrementActions
+  }
+})
+runTests('Diff – Array as clearHistoryType', {
+  undoableConfig: {
+    enableDiff: true,
+    clearHistoryType: ['TYPE_1', 'TYPE_2']
+  }
+})
 
 // Test undoable reducers as a function of a configuration object
 // `label` describes the nature of the configuration object used to run a test
@@ -298,14 +342,18 @@ function runTests (label, { undoableConfig = {}, initialStoreState, testConfig }
       })
 
       it('should change present state to last element of \'past\'', () => {
-        if (undoableConfig && undoableConfig.limit >= 0) {
-          expect(undoState.present).to.equal(incrementedState.past[incrementedState.past.length - 1])
+        if (undoableConfig && !undoableConfig.enableDiff) {
+          if (undoableConfig.limit >= 0) {
+            expect(undoState.present).to.equal(incrementedState.past[incrementedState.past.length - 1])
+          }
         }
       })
 
       it('should add a new element to \'future\' from last state', () => {
-        if (undoableConfig && undoableConfig.limit >= 0) {
-          expect(undoState.future[0]).to.equal(incrementedState.present)
+        if (undoableConfig && !undoableConfig.enableDiff) {
+          if (undoableConfig.limit >= 0) {
+            expect(undoState.future[0]).to.equal(incrementedState.present)
+          }
         }
       })
 
@@ -368,14 +416,18 @@ function runTests (label, { undoableConfig = {}, initialStoreState, testConfig }
       })
 
       it('should change present state to first element of \'future\'', () => {
-        if (undoableConfig && undoableConfig.limit >= 0) {
-          expect(redoState.present).to.equal(undoState.future[0])
+        if (undoableConfig && !undoableConfig.enableDiff) {
+          if (undoableConfig.limit >= 0) {
+            expect(redoState.present).to.equal(undoState.future[0])
+          }
         }
       })
 
       it('should add a new element to \'past\' from last state', () => {
-        if (undoableConfig && undoableConfig.limit >= 0) {
-          expect(redoState.past[redoState.past.length - 1]).to.equal(undoState.present)
+        if (undoableConfig && !undoableConfig.enableDiff) {
+          if (undoableConfig.limit >= 0) {
+            expect(redoState.past[redoState.past.length - 1]).to.equal(undoState.present)
+          }
         }
       })
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -75,6 +75,12 @@ runTests('Erroneous configuration', {
     future: []
   }
 })
+runTests('Diff', {
+  undoableConfig: {
+    enableDiff: true
+  }
+})
+
 
 // Test undoable reducers as a function of a configuration object
 // `label` describes the nature of the configuration object used to run a test


### PR DESCRIPTION
This PR implements a fully fledged diff + patching algorithm in order to store undo states by their differences, instead of entire copies of the state at each step.

I came across [this issue](https://github.com/omnidan/redux-undo/issues/36) and thought I might try to tackle it. I was planning on using a dependency for the diff logic, but it turns out there's not really a fully-featured diff library for JS out there. My requirements specifically were:

- Because this will be responsible for diff-ing entire redux states, be able to handle JS objects of all different types, including objects with prototype chains
- Track insertion / deletions of specific paths – including insertion of a single element into an array!
- be able to handle sneaky edge cases, like detecting the difference between `{ a: undefined}` and `{}` (If you're not careful, testing `obj["a"] === undefined` will falsely lead you to assume that the key "a" is _not_ in obj!)
- given only the information in the diff object, be able to both apply and revert the diff onto a base.

The diff format itself is loosely based on an existing deep-diff project [here](https://github.com/flitbit/diff). Given this code example:

```javascript
var lhs = {
    name: 'my object',
    description: 'it\'s an object!',
    details: {
        it: 'has',
        an: 'array',
        with: ['a', 'few', 'elements']
    }
};

var rhs = {
    name: 'updated object',
    description: 'it\'s an object!',
    details: {
        it: 'has',
        an: 'array',
        with: ['a', 'few', 'more', 'elements', { than: 'before' }]
    }
};

var differences = diff(lhs, rhs);
```

The algorithm will return the following:

```javascript
[ { kind: 'E',
    path: [ 'name' ],
    lhs: 'my object',
    rhs: 'updated object' },
  { kind: 'N', path: [ 'details', 'with', 2 ], rhs: 'more' },
  { kind: 'N',
    path: [ 'details', 'with', 4 ],
    rhs: { than: 'before' } } ]
```

Note the insertion detection on element 2 of the `width` array, and the consolidated path array containing both strings and integers, respectively for object keys and array keys.

The diff mode can be turned on by passing `enableDiff: true` to undoable.

I threw this together in a few days, so some bugs might still be hiding in the diffing/patching code. The testing code is mostly still intact; I added the existing test configs with diffing mode enabled, but then disabled all the tests that rely on the past / future arrays being structured in a certain way. It's not perfect, but I think it's a good starting point to something that can be reliable.
