### PR TITLE
doc: add details on redux-undo configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ undoable(reducer, {
 
   debug: false, // set to `true` to turn on debugging
 
-  neverSkipReducer: false, // prevent undoable from skipping the reducer on undo/redo
+  neverSkipReducer: false, // prevent undoable from skipping the reducer on undo/redo and clearHistoryType actions
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -156,8 +156,10 @@ undoable(reducer, {
 
   clearHistoryType: ActionTypes.CLEAR_HISTORY, // [beta only] define custom action type for this clearHistory action
   // you can also pass an array of strings to define several action types that would clear the history
+  // beware those action will not be passed down to the wrapped reducers
 
   initTypes: ['@@redux-undo/INIT'] // history will be (re)set upon init action type
+  // beware those action will not be passed down to the wrapped reducers
 
   debug: false, // set to `true` to turn on debugging
 

--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ undoable(reducer, {
 
   clearHistoryType: ActionTypes.CLEAR_HISTORY, // [beta only] define custom action type for this clearHistory action
   // you can also pass an array of strings to define several action types that would clear the history
-  // beware those action will not be passed down to the wrapped reducers
+  // beware: those actions will not be passed down to the wrapped reducers
 
   initTypes: ['@@redux-undo/INIT'] // history will be (re)set upon init action type
-  // beware those action will not be passed down to the wrapped reducers
+  // beware: those actions will not be passed down to the wrapped reducers
 
   debug: false, // set to `true` to turn on debugging
 


### PR DESCRIPTION
Add a note on the fact that `clearHistoryType` and `initTypes` will not be passed down to the wrapped reducer.