### PR TITLE
Squash

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -34,6 +34,8 @@ declare module 'redux-undo' {
 
     /** If you don't want to include every action in the undo/redo history, you can add a filter function to undoable */
     filter?: FilterFunction;
+    /** A function that returns a boolean whether you want the present state to be reflected in the next history insertion */
+    squash?: FilterFunction;
 
     /** Define a custom action type for this undo action */
     undoType?: string;


### PR DESCRIPTION
As promised, the `squash` function described in https://github.com/omnidan/redux-undo/issues/158

```js
config = {
  squash: (action: Action, state: State, history: StateWithHistory<State>) => boolean
}
```

- a config entry that allow users to synchronize the `_latestUnfiltered` state with the `present` state
- When a `Filtered&Squashed action` is dispatched:
  - _latestUnfiltered will become the most recent `present`
- When a `Not-Filtered&Squashed action` is dispatched:
  - _latestUnfiltered will become the latest `present` just before the history insertion.
- When a `Filtered&Not-Squashed action` is dispatched: same as before.
- When a `Not-Filtered&Not-Squashed action` is dispatched: same as before.