### PR TITLE
Groupby

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,44 @@ const store = createStore(undoable(counter), {foo: 'bar'});
 
 ```
 
+### Grouping Actions
+If you want to group your actions together into single undo/redo steps, you
+can add a `groupBy` function to `undoable`. `redux-undo` provides
+`groupByActionTypes` as a basic groupBy function:
+
+```js
+import undoable, { groupByActionTypes } from 'redux-undo';
+
+undoable(reducer, { groupBy: groupByActionTypes(SOME_ACTION) })
+// or with arrays
+undoable(reducer, { groupBy: groupByActionTypes([SOME_ACTION]) })
+```
+
+In these cases, consecutive SOME_ACTION actions will be considered a single
+step in the undo/redo history.
+
+### Further GroupBy Explanation
+
+If you want to create your own `groupBy` function, pass in your own function
+with the signature `(action, currentState, previousHistory)`. If the return
+value is not null, then the new state will be grouped by that return value.
+If the next state is grouped into the same group as the previous state, then
+the two states will be grouped together in one step.
+
+If the groupBy return value is `null`, then the state will not be grouped, and
+`redux-undo` not group the next state with the previous state.
+
+The `groupByActionTypes` function essentially returns the following:
+* If a grouped action type (`SOME_ACTION`), the action type of the action (`SOME_ACTION`).
+* If not a grouped action type (any other action type), `null`.
+
+When groupBy runs groups a state change, the associated `group` will be saved
+alongside `past`, `present`, and `future` so that it may be referenced by the
+next state change.
+
+After an undo/redo occurs, the current group gets reset to `null` so that the
+undo/redo history is remembered.
+
 ### Filtering Actions
 
 If you don't want to include every action in the undo/redo history, you can

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ When groupBy runs groups a state change, the associated `group` will be saved
 alongside `past`, `present`, and `future` so that it may be referenced by the
 next state change.
 
-After an undo/redo occurs, the current group gets reset to `null` so that the
+After an undo/redo/jump occurs, the current group gets reset to `null` so that the
 undo/redo history is remembered.
 
 ### Filtering Actions

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -49,3 +49,8 @@ export function combineFilters (...filters) {
       curr(action, currentState, previousHistory)
   , () => true)
 }
+
+export function groupByActionTypes (rawActions) {
+  const actions = parseActions(rawActions)
+  return (action) => actions.indexOf(action.type) >= 0 ? action.type : null
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ export { ActionTypes, ActionCreators } from './actions'
 export {
   parseActions, isHistory,
   distinctState, includeAction, excludeAction,
-  combineFilters
+  combineFilters, groupByActionTypes
 } from './helpers'
 
 export { default } from './reducer'

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -10,7 +10,7 @@ function lengthWithoutFuture (history) {
 // insert: insert `state` into history, which means adding the current state
 //         into `past`, setting the new `state` as `present` and erasing
 //         the `future`.
-function insert (history, state, limit) {
+function insert (history, state, limit, group) {
   debug.log('inserting', state)
   debug.log('new free: ', limit - lengthWithoutFuture(history))
 
@@ -28,7 +28,8 @@ function insert (history, state, limit) {
     past: newPast,
     present: state,
     _latestUnfiltered: state,
-    future: []
+    future: [],
+    group: group
   }
 }
 
@@ -49,7 +50,8 @@ function undo (history) {
     past: past.slice(0, past.length - 1), // remove last element from past
     present: newPresent, // set element as new present
     _latestUnfiltered: newPresent,
-    future: newFuture
+    future: newFuture,
+    group: null
   }
 }
 
@@ -70,7 +72,8 @@ function redo (history) {
     future: future.slice(1, future.length), // remove element from future
     present: newPresent, // set element as new present
     _latestUnfiltered: newPresent,
-    past: newPast
+    past: newPast,
+    group: null
   }
 }
 
@@ -87,8 +90,9 @@ function jumpToFuture (history, index) {
     future: future.slice(index + 1),
     present: newPresent,
     _latestUnfiltered: newPresent,
-    past: past.concat([_latestUnfiltered])
-      .concat(future.slice(0, index))
+    past: past.concat([_latestUnfiltered]).concat(future.slice(0, index)),
+    group: null
+
   }
 }
 
@@ -107,7 +111,8 @@ function jumpToPast (history, index) {
       .concat(future),
     present: newPresent,
     _latestUnfiltered: newPresent,
-    past: past.slice(0, index)
+    past: past.slice(0, index),
+    group: null
   }
 }
 
@@ -126,12 +131,14 @@ function createHistory (state, ignoreInitialState) {
   return ignoreInitialState ? {
     past: [],
     present: state,
-    future: []
+    future: [],
+    group: null
   } : {
     past: [],
     present: state,
     _latestUnfiltered: state,
-    future: []
+    future: [],
+    group: null
   }
 }
 
@@ -148,6 +155,7 @@ export default function undoable (reducer, rawConfig = {}) {
     initTypes: parseActions(rawConfig.initTypes, ['@@redux-undo/INIT']),
     limit: rawConfig.limit,
     filter: rawConfig.filter || (() => true),
+    groupBy: rawConfig.groupBy || (() => null),
     undoType: rawConfig.undoType || ActionTypes.UNDO,
     redoType: rawConfig.redoType || ActionTypes.REDO,
     jumpToPastType: rawConfig.jumpToPastType || ActionTypes.JUMP_TO_PAST,
@@ -179,7 +187,8 @@ export default function undoable (reducer, rawConfig = {}) {
         history = config.history = config.ignoreInitialState
           ? state : {
             ...state,
-            _latestUnfiltered: state.present
+            _latestUnfiltered: state.present,
+            group: null
           }
         debug.log('initialHistory initialized: initialState is a history', config.history)
       } else {
@@ -191,7 +200,7 @@ export default function undoable (reducer, rawConfig = {}) {
     const skipReducer = (res) => config.neverSkipReducer
       ? {
         ...res,
-        present: reducer(res.present, action, ...slices)
+        present: reducer(res.present, action, ...slices),
       } : res
 
     let res
@@ -254,18 +263,30 @@ export default function undoable (reducer, rawConfig = {}) {
           return history
         }
 
+        const group = config.groupBy(action, res, history)
+
         if (typeof config.filter === 'function' && !config.filter(action, res, history)) {
           // if filtering an action, merely update the present
-          const nextState = {
+          const filteredState = {
             ...history,
+            present: res,
+            group: null
+          }
+          debug.log('filter ignored action, not storing it in past')
+          debug.end(filteredState)
+          return filteredState
+        } else if (group != null && group === history.group) {
+          const groupedState = {
+            ...history,
+            _latestUnfiltered: res,
             present: res
           }
-          debug.log('filter prevented action, not storing it')
-          debug.end(nextState)
-          return nextState
+          debug.log('groupBy grouped the action with the previous action')
+          debug.end(groupedState)
+          return groupedState
         } else {
           // If the action wasn't filtered, insert normally
-          history = insert(history, res, config.limit)
+          history = insert(history, res, config.limit, group)
 
           debug.log('inserted new state into history')
           debug.end(history)

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -200,7 +200,7 @@ export default function undoable (reducer, rawConfig = {}) {
     const skipReducer = (res) => config.neverSkipReducer
       ? {
         ...res,
-        present: reducer(res.present, action, ...slices),
+        present: reducer(res.present, action, ...slices)
       } : res
 
     let res

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -172,7 +172,8 @@ function runTests (label, { undoableConfig = {}, initialStoreState, testConfig }
             past: [],
             present: initialStoreState,
             _latestUnfiltered: initialStoreState,
-            future: []
+            future: [],
+            group: null
           })
         }
       })
@@ -426,6 +427,8 @@ function runTests (label, { undoableConfig = {}, initialStoreState, testConfig }
           // redo
           const postRedoState = mockUndoableReducer(postUndoState, ActionCreators.redo())
           // redo should be ignored, because future state wasn't stored
+          console.log(postRedoState)
+          console.log(mockInitialState)
           expect(mockInitialState).to.deep.equal(postRedoState)
         }
       })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -314,42 +314,42 @@ function runTests (label, { undoableConfig = {}, initialStoreState, testConfig }
             type: 'INCREMENT',
             group: 'a'
           })
+          expect(first.past.length).to.equal(1)
           const second = mockUndoableReducer(first, {
             type: 'INCREMENT',
             group: 'a'
           })
+          expect(second.past.length).to.equal(first.past.length)
           const third = mockUndoableReducer(second, {
             type: 'INCREMENT',
             group: 'a'
           })
+          expect(third.past.length).to.equal(second.past.length)
+          expect(third.present).to.equal(mockInitialState.present + 3)
           const fourth = mockUndoableReducer(third, {
             type: 'DECREMENT',
             group: 'b'
           })
+          expect(fourth.past.length).to.equal(2)
           const fifth = mockUndoableReducer(fourth, {
             type: 'DECREMENT',
             group: 'b'
           })
+          expect(fifth.past.length).to.equal(fourth.past.length)
           const sixth = mockUndoableReducer(fifth, {
             type: 'DECREMENT',
             group: 'b'
           })
+          expect(sixth.past.length).to.equal(fifth.past.length)
+          expect(sixth.present).to.equal(mockInitialState.present)
           const seventh = mockUndoableReducer(sixth, {
             type: 'INCREMENT'
           })
+          expect(seventh.present).to.equal(first.present)
+          expect(seventh.past.length).to.equal(3)
           const eighth = mockUndoableReducer(seventh, {
             type: 'INCREMENT'
           })
-          expect(first.past.length).to.equal(1)
-          expect(second.past.length).to.equal(first.past.length)
-          expect(third.past.length).to.equal(second.past.length)
-          expect(third.present).to.equal(mockInitialState.present + 3)
-          expect(fourth.past.length).to.equal(2)
-          expect(fifth.past.length).to.equal(fourth.past.length)
-          expect(sixth.past.length).to.equal(fifth.past.length)
-          expect(sixth.present).to.equal(mockInitialState.present)
-          expect(seventh.present).to.equal(first.present)
-          expect(seventh.past.length).to.equal(3)
           expect(eighth.past.length).to.equal(4)
         }
       })
@@ -360,38 +360,38 @@ function runTests (label, { undoableConfig = {}, initialStoreState, testConfig }
             type: 'INCREMENT',
             group: 'a'
           })
+          expect(first.past.length).to.equal(1)
           const second = mockUndoableReducer(first, {
             type: 'INCREMENT',
             group: 'a'
           })
+          expect(second.past.length).to.equal(first.past.length)
           const third = mockUndoableReducer(second, ActionCreators.undo())
+          expect(third.past.length).to.equal(0)
+          expect(third.present).to.equal(mockInitialState.present)
           const fourth = mockUndoableReducer(third, ActionCreators.redo())
+          expect(fourth.past.length).to.equal(second.past.length)
+          expect(fourth.present).to.equal(second.present)
           const fifth = mockUndoableReducer(fourth, {
             type: 'INCREMENT',
             group: 'a'
           })
+          expect(fifth.past.length).to.equal(fourth.past.length + 1)
           const sixth = mockUndoableReducer(fifth, {
             type: 'DECREMENT',
             group: 'b'
           })
+          expect(sixth.past.length).to.equal(fifth.past.length + 1)
           const seventh = mockUndoableReducer(sixth, {
             type: 'DECREMENT',
             group: 'b'
           })
-          const eighth = mockUndoableReducer(seventh, ActionCreators.undo())
-          const ninth = mockUndoableReducer(eighth, ActionCreators.undo())
-          const tenth = mockUndoableReducer(ninth, ActionCreators.undo())
-          expect(first.past.length).to.equal(1)
-          expect(second.past.length).to.equal(first.past.length)
-          expect(third.past.length).to.equal(0)
-          expect(third.present).to.equal(mockInitialState.present)
-          expect(fourth.past.length).to.equal(second.past.length)
-          expect(fourth.present).to.equal(second.present)
-          expect(fifth.past.length).to.equal(fourth.past.length + 1)
-          expect(sixth.past.length).to.equal(fifth.past.length + 1)
           expect(seventh.past.length).to.equal(sixth.past.length)
+          const eighth = mockUndoableReducer(seventh, ActionCreators.undo())
           expect(eighth.present).to.equal(fifth.present)
+          const ninth = mockUndoableReducer(eighth, ActionCreators.undo())
           expect(ninth.present).to.equal(fourth.present)
+          const tenth = mockUndoableReducer(ninth, ActionCreators.undo())
           expect(tenth.present).to.equal(mockInitialState.present)
         }
       })

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -10,7 +10,7 @@ declare module 'redux-undo' {
   }
 
   export type FilterFunction = (action: Action) => boolean;
-  export type GroupByFunction = (action: Action) => any;
+  export type GroupByFunction = <State>(action: Action, currentState: State, previousHistory: StateWithHistory<State>) => any;
   export type CombineFilters = (...filters: FilterFunction[]) => FilterFunction;
 
   export class ActionCreators {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -5,9 +5,12 @@ declare module 'redux-undo' {
     past: State[];
     present: State;
     future: State[];
+    _latestUnfiltered: State[];
+    group: any;
   }
 
   export type FilterFunction = (action: Action) => boolean;
+  export type GroupByFunction = (action: Action) => any;
   export type CombineFilters = (...filters: FilterFunction[]) => FilterFunction;
 
   export class ActionCreators {
@@ -35,6 +38,9 @@ declare module 'redux-undo' {
     /** If you don't want to include every action in the undo/redo history, you can add a filter function to undoable */
     filter?: FilterFunction;
 
+    /** Groups actions together into one undo step */
+    groupBy?: GroupByFunction;
+
     /** Define a custom action type for this undo action */
     undoType?: string;
     /** Define a custom action type for this redo action */
@@ -56,7 +62,7 @@ declare module 'redux-undo' {
 
     /** Set to `true` to turn on debugging */
     debug?: boolean;
-    
+
     /** Set to `true` to prevent undoable from skipping the reducer on undo/redo **/
     neverSkipReducer?: boolean;
   }
@@ -68,6 +74,7 @@ declare module 'redux-undo' {
 
   type IncludeAction = (actions: string | string[]) => FilterFunction;
   type ExcludeAction = IncludeAction;
+  type GroupByActionTypes = (actions: string | string[]) => GroupByFunction;
 
   const undoable: Undoable;
 
@@ -86,4 +93,7 @@ declare module 'redux-undo' {
   export const excludeAction: ExcludeAction;
 
   export const combineFilters: CombineFilters;
+
+  export const groupByActionTypes: GroupByActionTypes;
+
 }


### PR DESCRIPTION
This sort of functionality has been brought up in #115, #158, and could likely provide a cleaner solution than the one I offered in #155. It provides an alternative approach to #160 by saving the group state along past/present/future rather than behaving like a filtering function.

Check out the tests for an example of how this might be used, where we can group actions into groups 'a' and 'b'--consecutive actions in the same group are treated as a single step.