### PR TITLE
syncFilter flag implementation

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -166,7 +166,8 @@ export default function undoable (reducer, rawConfig = {}) {
       ? rawConfig.clearHistoryType
       : [rawConfig.clearHistoryType || ActionTypes.CLEAR_HISTORY],
     neverSkipReducer: rawConfig.neverSkipReducer || false,
-    ignoreInitialState: rawConfig.ignoreInitialState || false
+    ignoreInitialState: rawConfig.ignoreInitialState || false,
+    syncFilter: rawConfig.syncFilter || false
   }
 
   return (state = config.history, action = {}, ...slices) => {
@@ -270,6 +271,7 @@ export default function undoable (reducer, rawConfig = {}) {
           const filteredState = {
             ...history,
             present: res,
+            _latestUnfiltered: config.syncFilter ? res : history._latestUnfiltered,
             group: null
           }
           debug.log('filter ignored action, not storing it in past')

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -277,6 +277,22 @@ function runTests (label, { undoableConfig = {}, initialStoreState, testConfig }
         expect(dummyState).to.deep.equal(incrementedState)
       })
 
+      it('should synchronize latest unfiltered state to present when filtering actions', () => {
+        if (testConfig && testConfig.excludedActions) {
+          const excludedAction = { type: testConfig.excludedActions[0] }
+
+          const synchronizedFilteredReducer = undoable(countReducer, {
+            ...undoableConfig,
+            syncFilter: true
+          })
+          let unsynchronized = mockUndoableReducer(mockInitialState, excludedAction)
+          let synchronized = synchronizedFilteredReducer(mockInitialState, excludedAction)
+          expect(unsynchronized.present).to.deep.equal(synchronized.present)
+          expect(unsynchronized._latestUnfiltered).to.not.deep.equal(synchronized._latestUnfiltered)
+          expect(synchronized.present).to.deep.equal(synchronized._latestUnfiltered)
+        }
+      })
+
       it('should not record undefined actions', () => {
         let dummyState = mockUndoableReducer(incrementedState, undefined)
         expect(dummyState).to.deep.equal(incrementedState)

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -68,6 +68,9 @@ declare module 'redux-undo' {
 
     /** Set to `true` to prevent the user from undoing to the initial state  **/
     ignoreInitialState?: boolean;
+
+    /** Set to `true` to synchronize the _latestUnfiltered state with present wen a excluded action is dispatched **/
+    syncFilter?: boolean;
   }
 
   interface Undoable {


### PR DESCRIPTION
As mentioned in https://github.com/omnidan/redux-undo/pull/161 and https://github.com/omnidan/redux-undo/pull/160

The spec:

When syncFilters is true and a unfiltered action is dispatched: The _latestUnfiltered state will change with the value of the present state
When syncFilters is false and a unfiltered action is dispatched: The _latestUnfiltered state will remain as before.
When a filtered action is dispatched: The syncFilters flag is irrelevant.