### PR TITLE
Upgrading dist and examples to webpack 2

### DIFF
--- a/examples/throttled-drag/package.json
+++ b/examples/throttled-drag/package.json
@@ -17,8 +17,8 @@
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
     "express": "^4.13.4",
-    "webpack": "^1.12.14",
-    "webpack-dev-middleware": "^1.6.0",
-    "webpack-hot-middleware": "^2.10.0"
+    "webpack": "^2.6.1",
+    "webpack-dev-middleware": "^1.10.2",
+    "webpack-hot-middleware": "^2.18.0"
   }
 }

--- a/examples/throttled-drag/webpack.config.js
+++ b/examples/throttled-drag/webpack.config.js
@@ -13,13 +13,13 @@ module.exports = {
     publicPath: '/static/'
   },
   plugins: [
-    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin()
   ],
   module: {
-    loaders: [{
+    rules: [{
       test: /\.js$/,
-      loaders: ['babel'],
+      use: ['babel-loader'],
       exclude: /node_modules/,
       include: __dirname
     }]

--- a/examples/todos-with-undo/package.json
+++ b/examples/todos-with-undo/package.json
@@ -30,8 +30,8 @@
     "expect": "^1.6.0",
     "express": "^4.13.3",
     "node-libs-browser": "^0.5.2",
-    "webpack": "^1.9.11",
-    "webpack-dev-middleware": "^1.2.0",
-    "webpack-hot-middleware": "^2.9.1"
+    "webpack": "^2.6.1",
+    "webpack-dev-middleware": "^1.10.2",
+    "webpack-hot-middleware": "^2.18.0"
   }
 }

--- a/examples/todos-with-undo/webpack.config.js
+++ b/examples/todos-with-undo/webpack.config.js
@@ -13,13 +13,13 @@ module.exports = {
     publicPath: '/static/'
   },
   plugins: [
-    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin()
   ],
   module: {
-    loaders: [{
+    rules: [{
       test: /\.js$/,
-      loaders: ['babel'],
+      use: ['babel-loader'],
       exclude: /node_modules/,
       include: __dirname
     }]

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "mocha-lcov-reporter": "^1.2.0",
     "npm-run-all": "^3.1.1",
     "rimraf": "^2.5.4",
-    "webpack": "^1.13.1"
+    "webpack": "^2.6.1"
   },
   "dependencies": {
     "redux": "^3.5.2"

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -4,7 +4,7 @@ import path from 'path'
 const { NODE_ENV } = process.env
 
 const plugins = [
-  new webpack.optimize.OccurenceOrderPlugin(),
+  new webpack.optimize.OccurrenceOrderPlugin(),
   new webpack.DefinePlugin({
     'process.env.NODE_ENV': JSON.stringify(NODE_ENV)
   })
@@ -26,8 +26,8 @@ NODE_ENV === 'production' && plugins.push(
 
 export default {
   module: {
-    loaders: [
-      { test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ }
+    rules: [
+      { test: /\.js$/, use: ['babel-loader'], exclude: /node_modules/ }
     ]
   },
 


### PR DESCRIPTION
📓 :

- Use webpack 2 to bundle the `UMD` distribution.
- Use webpack 2 to run the examples.

Nothing more, nothing less.