### PR TITLE
Refactor and index/limit

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -227,7 +227,12 @@ export default function undoable (reducer, rawConfig = {}) {
 
         if (filtered) {
           // if filtering an action, merely update the present
-          let filteredState = newHistory(history.past, res, history.future)
+          let filteredState = newHistory(
+            history.past,
+            res,
+            history.future,
+            history.group
+          )
           if (!config.syncFilter) {
             filteredState._latestUnfiltered = history._latestUnfiltered
           }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -17,7 +17,7 @@ function createHistory (state, ignoreInitialState) {
   // ignoreInitialState essentially prevents the user from undoing to the
   // beginning, in the case that the undoable reducer handles initialization
   // in a way that can't be redone simply
-  let history = newHistory([], state, [])
+  const history = newHistory([], state, [])
   return ignoreInitialState ? {
     ...history,
     _latestUnfiltered: null

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -8,7 +8,9 @@ function newHistory (past, present, future, group = null) {
     present,
     future,
     group,
-    _latestUnfiltered: present
+    _latestUnfiltered: present,
+    index: past.length,
+    limit: past.length + future.length + 1
   }
 }
 
@@ -17,11 +19,11 @@ function createHistory (state, ignoreInitialState) {
   // ignoreInitialState essentially prevents the user from undoing to the
   // beginning, in the case that the undoable reducer handles initialization
   // in a way that can't be redone simply
-  const history = newHistory([], state, [])
-  return ignoreInitialState ? {
-    ...history,
-    _latestUnfiltered: null
-  } : history
+  let history = newHistory([], state, [])
+  if (ignoreInitialState) {
+    history._latestUnfiltered = null
+  }
+  return history
 }
 
 // lengthWithoutFuture: get length of history
@@ -128,11 +130,11 @@ export default function undoable (reducer, rawConfig = {}) {
         debug.log('do not initialize on probe actions')
       } else if (isHistory(state)) {
         history = config.history = config.ignoreInitialState
-          ? state : {
-            ...state,
-            _latestUnfiltered: state.present,
-            group: null
-          }
+          ? state : newHistory(
+            state.past,
+            state.present,
+            state.future
+          )
         debug.log('initialHistory initialized: initialState is a history', config.history)
       } else {
         history = config.history = createHistory(state)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -181,7 +181,9 @@ function runTests (label, { undoableConfig = {}, initialStoreState, testConfig }
             present: initialStoreState,
             _latestUnfiltered: initialStoreState,
             future: [],
-            group: null
+            group: null,
+            index: 0,
+            limit: 1
           })
         }
       })

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -7,6 +7,8 @@ declare module 'redux-undo' {
     future: State[];
     _latestUnfiltered: State[];
     group: any;
+    index: number;
+    limit: number;
   }
 
   export type FilterFunction = <State>(action: Action, currentState: State, previousHistory: StateWithHistory<State>) => boolean;


### PR DESCRIPTION
I removed undo and redo functions since the jump function handles their cases and I manage all state reassignments using the newHistory function so that standard behavior is handled appropriately and so that non-standard behavior feels more distinct (e.g. the createHistory function and the syncFilters flag).

Also, I added the index/limit mentioned in #162 since it's a trivial add with the refactor. I'd say the next section to focus on is history initialization and config management since both are a bit confusing

Also, add in fix for https://github.com/omnidan/redux-undo/issues/171