### PR TITLE
Fix typings for latestUnfiltered property

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -5,7 +5,7 @@ declare module 'redux-undo' {
     past: State[];
     present: State;
     future: State[];
-    _latestUnfiltered: State[];
+    _latestUnfiltered: State;
     group: any;
   }
 


### PR DESCRIPTION
Fix for issue https://github.com/omnidan/redux-undo/issues/169 `_latestUnfiltered` typings is wrong.  I'll appreciate a quick version bump for this @omnidan @davidroeca !