### PR TITLE
handle #173

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -212,7 +212,7 @@ export default function undoable (reducer, rawConfig = {}) {
           return config.history
         }
 
-        if (history.present === res) {
+        if (history._latestUnfiltered === res) {
           // Don't handle this action. Do not call debug.end here,
           // because this action should not produce side effects to the console
           return history


### PR DESCRIPTION
See #173 and #171 

The thought here is that distinct states should be ignored only as they relate to the state that was last unfiltered. If `syncFilters` is set to true, then there will be no difference in behavior. When dealing with filtered states, the history doesn't get updated. It makes sense to only focus on unfiltered states with the distinct state filter