### PR TITLE
export newHistory function

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -54,3 +54,15 @@ export function groupByActionTypes (rawActions) {
   const actions = parseActions(rawActions)
   return (action) => actions.indexOf(action.type) >= 0 ? action.type : null
 }
+
+export function newHistory (past, present, future, group = null) {
+  return {
+    past,
+    present,
+    future,
+    group,
+    _latestUnfiltered: present,
+    index: past.length,
+    limit: past.length + future.length + 1
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ export { ActionTypes, ActionCreators } from './actions'
 export {
   parseActions, isHistory,
   distinctState, includeAction, excludeAction,
-  combineFilters, groupByActionTypes
+  combineFilters, groupByActionTypes, newHistory
 } from './helpers'
 
 export { default } from './reducer'

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,18 +1,6 @@
 import * as debug from './debug'
 import { ActionTypes } from './actions'
-import { parseActions, isHistory } from './helpers'
-
-function newHistory (past, present, future, group = null) {
-  return {
-    past,
-    present,
-    future,
-    group,
-    _latestUnfiltered: present,
-    index: past.length,
-    limit: past.length + future.length + 1
-  }
-}
+import { parseActions, isHistory, newHistory } from './helpers'
 
 // createHistory
 function createHistory (state, ignoreInitialState) {


### PR DESCRIPTION
This PR allows people to stay in sync with the histories that redux-undo creates so that they can refresh states more easily

See #163 and conversation in #117 for some rationale behind this