### PR TITLE
Fix Filtered Actions

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -215,11 +215,10 @@ export default function undoable (reducer, rawConfig = {}) {
         const group = config.groupBy(action, res, history)
 
         if (filtered) {
-          // if filtering an action, merely update the present
           let filteredState = newHistory(
-            history.past,
+            history.past.map((past) => reducer(past, action, ...slices)),
             res,
-            history.future,
+            history.future.map((future) => reducer(future, action, ...slices)),
             history.group
           )
           if (!config.syncFilter) {


### PR DESCRIPTION
This is a minor change regarding filtered actions. When a filtered action is dispatched, the history is not modified in any way (no new entries or removed entries), which is how you would expect it to work. Although these actions can result in state changes, so the present state is updated with that change but all history entries (past / future) are not updated.

I feel like the expected behavior would be to update all state (present, past, future) when an filtered action is dispatched because otherwise the state change of the filtered action is reverted when you undo the last non-filtered action.

I have not updated the tests to work with this change but I will do so if this change makes sense to the maintainer(s).