### PR TITLE
Add typings for newHistory; add example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ const initialHistory = {
   future: [5, 6, 7]
 }
 
+// Alternatively use the helper:
+// import { newHistory } from 'redux-undo';
+// const initialHistory = newHistory([0, 1, 2, 3], 4, [5, 6, 7]);
+
 const store = createStore(undoable(counter), initialHistory);
 
 ```

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -83,6 +83,7 @@ declare module 'redux-undo' {
   type IncludeAction = (actions: string | string[]) => FilterFunction;
   type ExcludeAction = IncludeAction;
   type GroupByActionTypes = (actions: string | string[]) => GroupByFunction;
+  type NewHistory = <State>(past: State[], present: State, future: State[], group?: any) => StateWithHistory<State>;
 
   const undoable: Undoable;
 
@@ -103,5 +104,7 @@ declare module 'redux-undo' {
   export const combineFilters: CombineFilters;
 
   export const groupByActionTypes: GroupByActionTypes;
+
+  export const newHistory: NewHistory;
 
 }


### PR DESCRIPTION
I tried to use `newHistory`, and I quickly realized it was missing from the type definitions!