### PR TITLE
Fix typings for `GroupByFunction`

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -12,7 +12,7 @@ declare module 'redux-undo' {
   }
 
   export type FilterFunction = <State>(action: Action, currentState: State, previousHistory: StateWithHistory<State>) => boolean;
-  export type GroupByFunction = (action: Action) => any;
+  export type GroupByFunction = <State>(action: Action, currentState?: State, previousHistory?: StateWithHistory<State>) => any;
   export type CombineFilters = (...filters: FilterFunction[]) => FilterFunction;
 
   export class ActionCreators {


### PR DESCRIPTION
The typings for `GroupByFunction` were missing 2 arguments as explained here https://github.com/omnidan/redux-undo#custom-groupby-function
This is also used here with 3 arguments: https://github.com/omnidan/redux-undo/blob/322437c37553ab224783ef4ca0dc4508485c84c7/src/reducer.js#L236