### PR TITLE
Add stronger type enforcements

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -11,9 +11,9 @@ declare module 'redux-undo' {
     limit?: number;
   }
 
-  export type FilterFunction = <State>(action: Action, currentState: State, previousHistory: StateWithHistory<State>) => boolean;
-  export type GroupByFunction = <State>(action: Action, currentState: State, previousHistory: StateWithHistory<State>) => any;
-  export type CombineFilters = (...filters: FilterFunction[]) => FilterFunction;
+  export type FilterFunction<S, A extends Action> = (action: A, currentState: S, previousHistory: StateWithHistory<S>) => boolean;
+  export type GroupByFunction<S, A extends Action> = (action: A, currentState: S, previousHistory: StateWithHistory<S>) => any;
+  export type CombineFilters<S = any, A extends Action = AnyAction> = (...filters: FilterFunction<S, A>[]) => FilterFunction<S, A>;
 
   export class ActionCreators {
     static undo: () => Action;
@@ -33,15 +33,15 @@ declare module 'redux-undo' {
     static CLEAR_HISTORY: string;
   }
 
-  export interface UndoableOptions {
+  export interface UndoableOptions<S, A extends Action> {
     /* Set a limit for the history */
     limit?: number;
 
     /** If you don't want to include every action in the undo/redo history, you can add a filter function to undoable */
-    filter?: FilterFunction;
+    filter?: FilterFunction<S, A>;
 
     /** Groups actions together into one undo step */
-    groupBy?: GroupByFunction;
+    groupBy?: GroupByFunction<S, A>;
 
     /** Define a custom action type for this undo action */
     undoType?: string;
@@ -76,13 +76,12 @@ declare module 'redux-undo' {
   }
 
   interface Undoable {
-    <State, A extends Action = AnyAction>(reducer: Reducer<State, A>, options?: UndoableOptions): Reducer<StateWithHistory<State>>;
+    <S, A extends Action>(reducer: Reducer<S, A>, options?: UndoableOptions<S, A>): Reducer<StateWithHistory<S>>;
   }
 
-
-  type IncludeAction = (actions: string | string[]) => FilterFunction;
+  type IncludeAction = <S, A extends Action = AnyAction>(actions: Pick<A, 'type'>['type'] | Pick<A, 'type'>['type'][]) => FilterFunction<S, A>;
   type ExcludeAction = IncludeAction;
-  type GroupByActionTypes = (actions: string | string[]) => GroupByFunction;
+  type GroupByActionTypes = <S, A extends Action = AnyAction>(actions: Pick<A, 'type'>['type'] | Pick<A, 'type'>['type'][]) => GroupByFunction<S, A>;
   type NewHistory = <State>(past: State[], present: State, future: State[], group?: any) => StateWithHistory<State>;
 
   const undoable: Undoable;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -79,9 +79,9 @@ declare module 'redux-undo' {
     <S, A extends Action>(reducer: Reducer<S, A>, options?: UndoableOptions<S, A>): Reducer<StateWithHistory<S>>;
   }
 
-  type IncludeAction = <S, A extends Action = AnyAction>(actions: Pick<A, 'type'>['type'] | Pick<A, 'type'>['type'][]) => FilterFunction<S, A>;
+  type IncludeAction = <S, A extends Action = AnyAction>(actions: A['type'] | A['type'][]) => FilterFunction<S, A>;
   type ExcludeAction = IncludeAction;
-  type GroupByActionTypes = <S, A extends Action = AnyAction>(actions: Pick<A, 'type'>['type'] | Pick<A, 'type'>['type'][]) => GroupByFunction<S, A>;
+  type GroupByActionTypes = <S, A extends Action = AnyAction>(actions: A['type'] | A['type'][]) => GroupByFunction<S, A>;
   type NewHistory = <State>(past: State[], present: State, future: State[], group?: any) => StateWithHistory<State>;
 
   const undoable: Undoable;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -76,7 +76,7 @@ declare module 'redux-undo' {
   }
 
   interface Undoable {
-    <S = any, A extends Action = AnyAction>(reducer: Reducer<S, A>, options?: UndoableOptions<S, A>): Reducer<StateWithHistory<S>>;
+    <State, A extends Action = AnyAction>(reducer: Reducer<State, A>, options?: UndoableOptions<State, A>): Reducer<StateWithHistory<State>>;
   }
 
   type IncludeAction = <S = any, A extends Action = AnyAction>(actions: A['type'] | A['type'][]) => FilterFunction<S, A>;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -11,8 +11,8 @@ declare module 'redux-undo' {
     limit?: number;
   }
 
-  export type FilterFunction<S, A extends Action> = (action: A, currentState: S, previousHistory: StateWithHistory<S>) => boolean;
-  export type GroupByFunction<S, A extends Action> = (action: A, currentState: S, previousHistory: StateWithHistory<S>) => any;
+  export type FilterFunction<S = any, A extends Action = AnyAction> = (action: A, currentState: S, previousHistory: StateWithHistory<S>) => boolean;
+  export type GroupByFunction<S = any, A extends Action = AnyAction> = (action: A, currentState: S, previousHistory: StateWithHistory<S>) => any;
   export type CombineFilters<S = any, A extends Action = AnyAction> = (...filters: FilterFunction<S, A>[]) => FilterFunction<S, A>;
 
   export class ActionCreators {
@@ -33,7 +33,7 @@ declare module 'redux-undo' {
     static CLEAR_HISTORY: string;
   }
 
-  export interface UndoableOptions<S, A extends Action> {
+  export interface UndoableOptions<S = any, A extends Action = AnyAction> {
     /* Set a limit for the history */
     limit?: number;
 
@@ -76,12 +76,13 @@ declare module 'redux-undo' {
   }
 
   interface Undoable {
-    <S, A extends Action>(reducer: Reducer<S, A>, options?: UndoableOptions<S, A>): Reducer<StateWithHistory<S>>;
+    <S = any, A extends Action = AnyAction>(reducer: Reducer<S, A>, options?: UndoableOptions<S, A>): Reducer<StateWithHistory<S>>;
   }
 
-  type IncludeAction = <S, A extends Action = AnyAction>(actions: A['type'] | A['type'][]) => FilterFunction<S, A>;
+  type IncludeAction = <S = any, A extends Action = AnyAction>(actions: A['type'] | A['type'][]) => FilterFunction<S, A>;
   type ExcludeAction = IncludeAction;
-  type GroupByActionTypes = <S, A extends Action = AnyAction>(actions: A['type'] | A['type'][]) => GroupByFunction<S, A>;
+  type CombineFilterFunctions = <S = any, A extends Action = AnyAction>(...filters: FilterFunction<S, A>[]) => FilterFunction<S, A>;
+  type GroupByActionTypes = <S = any, A extends Action = AnyAction>(actions: A['type'] | A['type'][]) => GroupByFunction<S, A>;
   type NewHistory = <State>(past: State[], present: State, future: State[], group?: any) => StateWithHistory<State>;
 
   const undoable: Undoable;
@@ -100,7 +101,7 @@ declare module 'redux-undo' {
    */
   export const excludeAction: ExcludeAction;
 
-  export const combineFilters: CombineFilters;
+  export const combineFilters: CombineFilterFunctions;
 
   export const groupByActionTypes: GroupByActionTypes;
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -13,7 +13,7 @@ declare module 'redux-undo' {
 
   export type FilterFunction<S = any, A extends Action = AnyAction> = (action: A, currentState: S, previousHistory: StateWithHistory<S>) => boolean;
   export type GroupByFunction<S = any, A extends Action = AnyAction> = (action: A, currentState: S, previousHistory: StateWithHistory<S>) => any;
-  export type CombineFilters<S = any, A extends Action = AnyAction> = (...filters: FilterFunction<S, A>[]) => FilterFunction<S, A>;
+  export type CombineFilters = <S = any, A extends Action = AnyAction>(...filters: FilterFunction<S, A>[]) => FilterFunction<S, A>;
 
   export class ActionCreators {
     static undo: () => Action;
@@ -81,7 +81,6 @@ declare module 'redux-undo' {
 
   type IncludeAction = <S = any, A extends Action = AnyAction>(actions: A['type'] | A['type'][]) => FilterFunction<S, A>;
   type ExcludeAction = IncludeAction;
-  type CombineFilterFunctions = <S = any, A extends Action = AnyAction>(...filters: FilterFunction<S, A>[]) => FilterFunction<S, A>;
   type GroupByActionTypes = <S = any, A extends Action = AnyAction>(actions: A['type'] | A['type'][]) => GroupByFunction<S, A>;
   type NewHistory = <State>(past: State[], present: State, future: State[], group?: any) => StateWithHistory<State>;
 
@@ -101,7 +100,7 @@ declare module 'redux-undo' {
    */
   export const excludeAction: ExcludeAction;
 
-  export const combineFilters: CombineFilterFunctions;
+  export const combineFilters: CombineFilters;
 
   export const groupByActionTypes: GroupByActionTypes;
 


### PR DESCRIPTION
<!-- Source: https://github.com/stevemao/github-issue-templates/tree/master/conversational -->

#### Please check if the PR fulfills these requirements

- Is this just a doc change? no
- If no, then check that:
    - [x] The commit message(s) are descriptive of the changes made
    - [x] The PR contains changes that are focused and differs from other  PRs
    - [x] Tests for the changes have been added where needed
    - [x] Docs have been added / updated

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

TypeScript definition update

#### What is the current behavior? (You can also link to an open issue here)

You can provide any string into a filter function, even if it not a valid action for the given reducer.

#### What is the new behavior?

When using TypeScript, TypeScript will display an error when you are giving filter functions an invalid action.
![image](https://user-images.githubusercontent.com/13830377/75728806-c3092a00-5c9d-11ea-995f-60ea6e5b22d4.png)

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

It shouldn't, if I did my types correctly. 

